### PR TITLE
Update color of navbar seperators to be visible.

### DIFF
--- a/packages/global/scss/index.scss
+++ b/packages/global/scss/index.scss
@@ -533,7 +533,7 @@ body {
     &__link::before {
       float: left;
       padding-right: $theme-site-navbar-primary-padding-x - 1;
-      color: $primary;
+      color: $black;
       content: "|";
     }
     &__item:first-child {


### PR DESCRIPTION
<img width="1920" alt="Screen Shot 2021-06-25 at 9 42 44 AM" src="https://user-images.githubusercontent.com/46794001/123441886-f447f080-d599-11eb-9759-7b0249637af8.png">
