### PR TITLE
Remove related content of type Venue and Supplier.

### DIFF
--- a/packages/global/components/blocks/related-content.marko
+++ b/packages/global/components/blocks/related-content.marko
@@ -8,7 +8,7 @@ $ const {
 
 <marko-web-query|{ nodes }|
   name="related-published-content"
-  params={ contentId: id, limit: 10, queryFragment }
+  params={ contentId: id, limit: 10, excludeContentTypes: ['Venue', 'Supplier'], queryFragment }
 >
   <global-content-list-flow nodes=nodes inner-justified=false>
     <@header>Related</@header>


### PR DESCRIPTION

<img width="1920" alt="Screen Shot 2021-06-30 at 2 36 04 PM" src="https://user-images.githubusercontent.com/46794001/124020895-81cb7c00-d9b0-11eb-93eb-6f8ebbb31b10.png">

These are already included in a separate block on the page and do not need to be duplicated in the related content block.