### PR TITLE
Update navbar links colors

### DIFF
--- a/packages/global/scss/index.scss
+++ b/packages/global/scss/index.scss
@@ -145,10 +145,10 @@ $theme-site-navbar-primary-font-size-sm:    12px;
 $theme-site-navbar-primary-font-weight:     700;
 $theme-site-navbar-primary-line-height:     1;
 
-$theme-site-navbar-primary-link-active-color:       $white;
+$theme-site-navbar-primary-link-active-color:       $black;
 $theme-site-navbar-primary-link-active-decoration:  none;
-$theme-site-navbar-primary-link-color:              $black;
-$theme-site-navbar-primary-link-hover-color:        $white;
+$theme-site-navbar-primary-link-color:              $white;
+$theme-site-navbar-primary-link-hover-color:        $black;
 
 $theme-site-navbar-secondary-bg-color:      $primary;
 $theme-site-navbar-secondary-font-size:     12px;
@@ -157,9 +157,10 @@ $theme-site-navbar-secondary-font-family:   $font-source-sans-pro;
 $theme-site-navbar-secondary-font-weight:   600;
 $theme-site-navbar-secondary-line-height:   1;
 
-$theme-site-navbar-secondary-link-color:              $black;
+$theme-site-navbar-secondary-link-active-color:       $black;
 $theme-site-navbar-secondary-link-active-decoration:  none;
-$theme-site-navbar-secondary-hover-color:             $white;
+$theme-site-navbar-secondary-link-color:              $black;
+$theme-site-navbar-secondary-link-hover-color:        $black;
 
 $theme-site-navbar-tertiary-link-active-color:  $white;
 $theme-site-navbar-tertiary-link-color:         $white;


### PR DESCRIPTION

<img width="1792" alt="Screen Shot 2021-07-08 at 7 51 07 AM" src="https://user-images.githubusercontent.com/46794001/124924637-44bf4500-dfc1-11eb-8f30-a68dc588dafd.png">
Active color is always black, secondary nav item is always black, hover-color is always black. Primary (unactive color) is always white.