### PR TITLE
Remove isLeader from content fragments

### DIFF
--- a/packages/global/graphql/fragments/content-company.js
+++ b/packages/global/graphql/fragments/content-company.js
@@ -1,7 +1,5 @@
 const gql = require('graphql-tag');
 
-const alias = process.env.LEADERS_ALIAS || 'leaders-2020';
-
 module.exports = gql`
 
 fragment WebsiteContentCompanyFragment on Content {
@@ -55,8 +53,6 @@ fragment WebsiteContentCompanyFragment on Content {
       src(input: { options: { auto: "format,compress", q: 70, fillColor: "fff", fit: "fill", h: 125, w: 125, pad: 5, mask: "ellipse" } })
       alt
     }
-
-    isLeader: hasWebsiteSchedule(input: { sectionAlias: "${alias}" })
 
     contacts: publicContacts {
       edges {

--- a/packages/global/graphql/fragments/content-page.js
+++ b/packages/global/graphql/fragments/content-page.js
@@ -170,7 +170,6 @@ fragment ContentPageFragment on Content {
   }
   ... on ContentCompany {
     email
-    isLeader: hasWebsiteSchedule(input: { sectionAlias: "leaders" })
   }
   ... on SocialLinkable {
     socialLinks {

--- a/packages/global/graphql/fragments/leadership-company-videos.js
+++ b/packages/global/graphql/fragments/leadership-company-videos.js
@@ -9,7 +9,6 @@ fragment LeadershipCompanyVideosFragment on Content {
     path
   }
   ... on ContentCompany {
-    isLeader: hasWebsiteSchedule(input: { sectionAlias: "leaders" })
     youtube {
       url
     }


### PR DESCRIPTION
Fix 
```
An unexpected error occurred: GraphQL error: No website.Section record found for ID {"status":1,"site.$id":"5b295afea1c1c62c008b4572","alias":"leaders-2020"}
```

That section doesn't exists.  and remove isLeaders check.  They currently are not using leaders.  