### PR TITLE
Remove ads from sponsored content, correct layout.

### DIFF
--- a/packages/global/components/blocks/content-load-more.marko
+++ b/packages/global/components/blocks/content-load-more.marko
@@ -19,7 +19,7 @@ $ const limit = displayAds ? 14 : 15
     query-name="all-author-content"
     query-params={
       skip: 4,
-      limit: limit,
+      limit,
       contactId: id,
       withSite: false,
     }
@@ -33,7 +33,7 @@ $ const limit = displayAds ? 14 : 15
     component-input={ displayAds, aliases }
     fragment-name="content-list"
     query-name="all-company-content"
-    query-params={ companyId: id, limit: limit, }
+    query-params={ companyId: id, limit, }
     page-input={ for: "content", id, type }
   />
 </else-if>
@@ -44,7 +44,7 @@ $ const limit = displayAds ? 14 : 15
     component-input={ displayAds, aliases, nativeX: input.nativeX }
     fragment-name="content-list"
     query-name="website-scheduled-content"
-    query-params={ sectionId, excludeContentIds: [id], limit: limit, skip: sectionSkip }
+    query-params={ sectionId, excludeContentIds: [id], limit, skip: sectionSkip }
     page-input={ for: "content", id, type }
   />
 </else-if>

--- a/packages/global/components/blocks/content-load-more.marko
+++ b/packages/global/components/blocks/content-load-more.marko
@@ -2,24 +2,24 @@ $ const {
   id,
   type,
   name,
-  primarySectionAlias,
+  displayAds,
   aliases,
   sectionId,
   sectionName,
   sectionSkip
 } = input;
-$ const limit = primarySectionAlias === 'sponsored' ? 15 : 14
+$ const limit = displayAds ? 14 : 15
 
 <if(type === "contact")>
   <marko-web-load-more
     header=`More from ${name}`
     component-name="content-load-more-flow"
-    component-input={ aliases }
+    component-input={ displayAds, aliases }
     fragment-name="content-list"
     query-name="all-author-content"
     query-params={
       skip: 4,
-      limit: 9,
+      limit: limit,
       contactId: id,
       withSite: false,
     }
@@ -30,10 +30,10 @@ $ const limit = primarySectionAlias === 'sponsored' ? 15 : 14
   <marko-web-load-more
     header=`More from ${name}`
     component-name="content-load-more-flow"
-    component-input={ aliases }
+    component-input={ displayAds, aliases }
     fragment-name="content-list"
     query-name="all-company-content"
-    query-params={ companyId: id }
+    query-params={ companyId: id, limit: limit, }
     page-input={ for: "content", id, type }
   />
 </else-if>
@@ -41,7 +41,7 @@ $ const limit = primarySectionAlias === 'sponsored' ? 15 : 14
   <marko-web-load-more
     header=`More in ${sectionName}`
     component-name="content-load-more-flow"
-    component-input={ primarySectionAlias, aliases, nativeX: input.nativeX }
+    component-input={ displayAds, aliases, nativeX: input.nativeX }
     fragment-name="content-list"
     query-name="website-scheduled-content"
     query-params={ sectionId, excludeContentIds: [id], limit: limit, skip: sectionSkip }

--- a/packages/global/components/blocks/content-load-more.marko
+++ b/packages/global/components/blocks/content-load-more.marko
@@ -7,6 +7,7 @@ $ const {
   sectionName,
   sectionSkip
 } = input;
+$ const limit = aliases.includes("sponsored") ? 15 : 14
 
 <if(type === "contact")>
   <marko-web-load-more
@@ -42,7 +43,7 @@ $ const {
     component-input={ aliases, nativeX: input.nativeX }
     fragment-name="content-list"
     query-name="website-scheduled-content"
-    query-params={ sectionId, excludeContentIds: [id], limit: 14, skip: sectionSkip }
+    query-params={ sectionId, excludeContentIds: [id], limit: limit, skip: sectionSkip }
     page-input={ for: "content", id, type }
   />
 </else-if>

--- a/packages/global/components/blocks/content-load-more.marko
+++ b/packages/global/components/blocks/content-load-more.marko
@@ -2,12 +2,13 @@ $ const {
   id,
   type,
   name,
+  primarySectionAlias,
   aliases,
   sectionId,
   sectionName,
   sectionSkip
 } = input;
-$ const limit = aliases.includes("sponsored") ? 15 : 14
+$ const limit = primarySectionAlias === 'sponsored' ? 15 : 14
 
 <if(type === "contact")>
   <marko-web-load-more
@@ -40,7 +41,7 @@ $ const limit = aliases.includes("sponsored") ? 15 : 14
   <marko-web-load-more
     header=`More in ${sectionName}`
     component-name="content-load-more-flow"
-    component-input={ aliases, nativeX: input.nativeX }
+    component-input={ primarySectionAlias, aliases, nativeX: input.nativeX }
     fragment-name="content-list"
     query-name="website-scheduled-content"
     query-params={ sectionId, excludeContentIds: [id], limit: limit, skip: sectionSkip }

--- a/packages/global/components/blocks/marko.json
+++ b/packages/global/components/blocks/marko.json
@@ -45,7 +45,7 @@
     "@type": "string",
     "@name": "string",
     "@aliases": "array",
-    "@primary-section-alias": "string",
+    "@display-ads": "boolean",
     "@section-id": "number",
     "@section-name": "string",
     "@section-skip": "number"

--- a/packages/global/components/blocks/marko.json
+++ b/packages/global/components/blocks/marko.json
@@ -45,6 +45,7 @@
     "@type": "string",
     "@name": "string",
     "@aliases": "array",
+    "@primary-section-alias": "string",
     "@section-id": "number",
     "@section-name": "string",
     "@section-skip": "number"

--- a/packages/global/components/flows/content-card-deck.marko
+++ b/packages/global/components/flows/content-card-deck.marko
@@ -26,13 +26,13 @@ $ const adPosition = input.adPosition || "after";
         />
       </marko-web-native-x-render>
     </@slot>
-    <if(adIndex !== null)>
+    <if(adIndex !== null && adName)>
       <@slot position=adPosition index=adIndex>
         <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: adName, size: [300, 250], aliases }) modifiers=["in-card"] />
       </@slot>
     </if>
   </default-theme-card-deck-flow>
-  <if(bottomLeaderboard)>
+  <if(bottomLeaderboard && adName)>
     <marko-web-gam-define-display-ad ...bottomLeaderboard modifiers=["bottom-leaderboard"] />
   </if>
 

--- a/packages/global/components/flows/content-card-deck.marko
+++ b/packages/global/components/flows/content-card-deck.marko
@@ -2,7 +2,7 @@ import { getAsArray, getAsObject } from "@parameter1/base-cms-object-path";
 
 $ const { site, GAM } = out.global;
 $ const nxConfig = site.get('nativeX');
-$ const { aliases, adIndex, adName, bottomLeaderboard, col, displayImage, withTeaser }  = input;
+$ const { primarySectionAlias, aliases, adIndex, adName, bottomLeaderboard, col, displayImage, withTeaser }  = input;
 $ const nodes = getAsArray(input, "nodes");
 $ const nativeX = getAsObject(input, "nativeX");
 $ const adPosition = input.adPosition || "after";
@@ -26,13 +26,13 @@ $ const adPosition = input.adPosition || "after";
         />
       </marko-web-native-x-render>
     </@slot>
-    <if(adIndex !== null && adName)>
+    <if(adIndex !== null && adName && primarySectionAlias !== 'sponsored')>
       <@slot position=adPosition index=adIndex>
         <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: adName, size: [300, 250], aliases }) modifiers=["in-card"] />
       </@slot>
     </if>
   </default-theme-card-deck-flow>
-  <if(bottomLeaderboard && adName)>
+  <if(bottomLeaderboard && adName && primarySectionAlias !== 'sponsored')>
     <marko-web-gam-define-display-ad ...bottomLeaderboard modifiers=["bottom-leaderboard"] />
   </if>
 

--- a/packages/global/components/flows/content-card-deck.marko
+++ b/packages/global/components/flows/content-card-deck.marko
@@ -2,7 +2,7 @@ import { getAsArray, getAsObject } from "@parameter1/base-cms-object-path";
 
 $ const { site, GAM } = out.global;
 $ const nxConfig = site.get('nativeX');
-$ const { primarySectionAlias, aliases, adIndex, adName, bottomLeaderboard, col, displayImage, withTeaser }  = input;
+$ const { aliases, adIndex, adName, bottomLeaderboard, col, displayImage, withTeaser }  = input;
 $ const nodes = getAsArray(input, "nodes");
 $ const nativeX = getAsObject(input, "nativeX");
 $ const adPosition = input.adPosition || "after";
@@ -32,8 +32,7 @@ $ const adPosition = input.adPosition || "after";
       </@slot>
     </if>
   </default-theme-card-deck-flow>
-  <if(bottomLeaderboard && primarySectionAlias !== 'sponsored')>
+  <if(bottomLeaderboard && adName)>
     <marko-web-gam-define-display-ad ...bottomLeaderboard modifiers=["bottom-leaderboard"] />
   </if>
-
 </if>

--- a/packages/global/components/flows/content-card-deck.marko
+++ b/packages/global/components/flows/content-card-deck.marko
@@ -32,7 +32,7 @@ $ const adPosition = input.adPosition || "after";
       </@slot>
     </if>
   </default-theme-card-deck-flow>
-  <if(bottomLeaderboard && adName && primarySectionAlias !== 'sponsored')>
+  <if(bottomLeaderboard && primarySectionAlias !== 'sponsored')>
     <marko-web-gam-define-display-ad ...bottomLeaderboard modifiers=["bottom-leaderboard"] />
   </if>
 

--- a/packages/global/components/flows/content-card-deck.marko
+++ b/packages/global/components/flows/content-card-deck.marko
@@ -26,13 +26,14 @@ $ const adPosition = input.adPosition || "after";
         />
       </marko-web-native-x-render>
     </@slot>
-    <if(adIndex !== null && adName)>
+    <if(adIndex !== null)>
       <@slot position=adPosition index=adIndex>
         <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: adName, size: [300, 250], aliases }) modifiers=["in-card"] />
       </@slot>
     </if>
   </default-theme-card-deck-flow>
-  <if(bottomLeaderboard && adName)>
+  <if(bottomLeaderboard)>
     <marko-web-gam-define-display-ad ...bottomLeaderboard modifiers=["bottom-leaderboard"] />
   </if>
+
 </if>

--- a/packages/global/components/flows/content-card-deck.marko
+++ b/packages/global/components/flows/content-card-deck.marko
@@ -26,7 +26,7 @@ $ const adPosition = input.adPosition || "after";
         />
       </marko-web-native-x-render>
     </@slot>
-    <if(adIndex !== null && adName && primarySectionAlias !== 'sponsored')>
+    <if(adIndex !== null && adName)>
       <@slot position=adPosition index=adIndex>
         <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: adName, size: [300, 250], aliases }) modifiers=["in-card"] />
       </@slot>

--- a/packages/global/components/flows/content-load-more.marko
+++ b/packages/global/components/flows/content-load-more.marko
@@ -33,13 +33,13 @@ $ const adName = "load-more";
           <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: adName, size: [300, 600], aliases }) modifiers=["in-card"] />
         </div>
         <div class="col-lg-8">
-          <global-content-card-deck-flow col=2 nodes=nodes.slice(10)/>
+          <global-content-card-deck-flow col=2 nodes=nodes3 />
         </div>
       </div>
     </if>
 
     <if(nodes4.length)>
-      <global-content-card-deck-flow nodes=nodes2 />
+      <global-content-card-deck-flow nodes=nodes4 />
     </if>
     <if(bottomLeaderboard)>
       <marko-web-gam-define-display-ad ...bottomLeaderboard />

--- a/packages/global/components/flows/content-load-more.marko
+++ b/packages/global/components/flows/content-load-more.marko
@@ -7,8 +7,9 @@ $ const {
   bottomLeaderboard,
 } = input;
 $ const nodes = getAsArray(input, "nodes");
+$ const adName = aliases.includes('sponsored') ? null : "load-more"
 
-<if(nodes.length)>
+<if(nodes.length && adName)>
   $ const nodes1 = nodes.slice(0,5);
   $ const nodes2 = nodes.slice(5,10);
   $ const nodes3 = nodes.slice(10, 14);
@@ -16,17 +17,17 @@ $ const nodes = getAsArray(input, "nodes");
 
   <!-- Card Deck flow with 300x250 in ad slot 4 -->
   <if(nodes1.length)>
-    <global-content-card-deck-flow nodes=nodes1 ad-index=4 ad-name="load-more" />
+    <global-content-card-deck-flow nodes=nodes1 ad-index=4 ad-name=adName />
   </if>
 
   <if(nodes2.length)>
-    <global-content-card-deck-flow nodes=nodes2 ad-index=2 ad-name="load-more" />
+    <global-content-card-deck-flow nodes=nodes2 ad-index=2 ad-name=adName />
   </if>
 
   <if(nodes3.length)>
     <div class="row">
       <div class="col-lg-4">
-        <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "load-more", size: [300, 600], aliases }) modifiers=["in-card"] />
+          <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: adName, size: [300, 600], aliases }) modifiers=["in-card"] />
       </div>
       <div class="col-lg-8">
         <global-content-card-deck-flow col=2 nodes=nodes.slice(10)/>
@@ -41,3 +42,6 @@ $ const nodes = getAsArray(input, "nodes");
     <marko-web-gam-define-display-ad ...bottomLeaderboard />
   </if>
 </if>
+<else>
+  <global-content-card-deck-flow nodes=nodes />
+</else>

--- a/packages/global/components/flows/content-load-more.marko
+++ b/packages/global/components/flows/content-load-more.marko
@@ -8,8 +8,8 @@ $ const {
   bottomLeaderboard,
 } = input;
 $ const nodes = getAsArray(input, "nodes");
-$ const displayAds = defaultValue(input.displayAds, true)
-$ const adName = "load-more"
+$ const displayAds = defaultValue(input.displayAds, true);
+$ const adName = "load-more";
 
 <if(nodes.length)>
   <if(displayAds)>

--- a/packages/global/components/flows/content-load-more.marko
+++ b/packages/global/components/flows/content-load-more.marko
@@ -9,7 +9,7 @@ $ const {
 } = input;
 $ const nodes = getAsArray(input, "nodes");
 $ const displayAds = defaultValue(input.displayAds, true)
-$ const adName = displayAds ? "load-more" : null;
+$ const adName = "load-more"
 
 <if(nodes.length)>
   <if(displayAds)>

--- a/packages/global/components/flows/content-load-more.marko
+++ b/packages/global/components/flows/content-load-more.marko
@@ -3,11 +3,12 @@ import { getAsArray, getAsObject } from "@parameter1/base-cms-object-path";
 $ const { GAM } = out.global;
 
 $ const {
+  primarySectionAlias,
   aliases,
   bottomLeaderboard,
 } = input;
 $ const nodes = getAsArray(input, "nodes");
-$ const adName = aliases.includes('sponsored') ? null : "load-more"
+$ const adName = primarySectionAlias === 'sponsored' ? null : "load-more"
 
 <if(nodes.length && adName)>
   $ const nodes1 = nodes.slice(0,5);
@@ -43,5 +44,5 @@ $ const adName = aliases.includes('sponsored') ? null : "load-more"
   </if>
 </if>
 <else>
-  <global-content-card-deck-flow nodes=nodes />
+  <global-content-card-deck-flow nodes=nodes primary-section-alias=primarySectionAlias/>
 </else>

--- a/packages/global/components/flows/content-load-more.marko
+++ b/packages/global/components/flows/content-load-more.marko
@@ -27,7 +27,7 @@ $ const adName = aliases.includes('sponsored') ? null : "load-more"
   <if(nodes3.length)>
     <div class="row">
       <div class="col-lg-4">
-          <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: adName, size: [300, 600], aliases }) modifiers=["in-card"] />
+        <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: adName, size: [300, 600], aliases }) modifiers=["in-card"] />
       </div>
       <div class="col-lg-8">
         <global-content-card-deck-flow col=2 nodes=nodes.slice(10)/>

--- a/packages/global/components/flows/content-load-more.marko
+++ b/packages/global/components/flows/content-load-more.marko
@@ -1,48 +1,51 @@
 import { getAsArray, getAsObject } from "@parameter1/base-cms-object-path";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
 $ const { GAM } = out.global;
 
 $ const {
-  primarySectionAlias,
   aliases,
   bottomLeaderboard,
 } = input;
 $ const nodes = getAsArray(input, "nodes");
-$ const adName = primarySectionAlias === 'sponsored' ? null : "load-more"
+$ const displayAds = defaultValue(input.displayAds, true)
+$ const adName = displayAds ? "load-more" : null;
 
-<if(nodes.length && adName)>
-  $ const nodes1 = nodes.slice(0,5);
-  $ const nodes2 = nodes.slice(5,10);
-  $ const nodes3 = nodes.slice(10, 14);
-  $ const nodes4 = nodes.slice(14);
+<if(nodes.length)>
+  <if(displayAds)>
+    $ const nodes1 = nodes.slice(0,5);
+    $ const nodes2 = nodes.slice(5,10);
+    $ const nodes3 = nodes.slice(10, 14);
+    $ const nodes4 = nodes.slice(14);
 
-  <!-- Card Deck flow with 300x250 in ad slot 4 -->
-  <if(nodes1.length)>
-    <global-content-card-deck-flow nodes=nodes1 ad-index=4 ad-name=adName />
-  </if>
+    <!-- Card Deck flow with 300x250 in ad slot 4 -->
+    <if(nodes1.length)>
+      <global-content-card-deck-flow nodes=nodes1 ad-index=4 ad-name=adName />
+    </if>
 
-  <if(nodes2.length)>
-    <global-content-card-deck-flow nodes=nodes2 ad-index=2 ad-name=adName />
-  </if>
+    <if(nodes2.length)>
+      <global-content-card-deck-flow nodes=nodes2 ad-index=2 ad-name=adName />
+    </if>
 
-  <if(nodes3.length)>
-    <div class="row">
-      <div class="col-lg-4">
-        <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: adName, size: [300, 600], aliases }) modifiers=["in-card"] />
+    <if(nodes3.length)>
+      <div class="row">
+        <div class="col-lg-4">
+          <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: adName, size: [300, 600], aliases }) modifiers=["in-card"] />
+        </div>
+        <div class="col-lg-8">
+          <global-content-card-deck-flow col=2 nodes=nodes.slice(10)/>
+        </div>
       </div>
-      <div class="col-lg-8">
-        <global-content-card-deck-flow col=2 nodes=nodes.slice(10)/>
-      </div>
-    </div>
-  </if>
+    </if>
 
-  <if(nodes4.length)>
-    <global-content-card-deck-flow nodes=nodes2 />
+    <if(nodes4.length)>
+      <global-content-card-deck-flow nodes=nodes2 />
+    </if>
+    <if(bottomLeaderboard)>
+      <marko-web-gam-define-display-ad ...bottomLeaderboard />
+    </if>
   </if>
-  <if(bottomLeaderboard)>
-    <marko-web-gam-define-display-ad ...bottomLeaderboard />
-  </if>
+  <else>
+    <global-content-card-deck-flow nodes=nodes />
+  </else>
 </if>
-<else>
-  <global-content-card-deck-flow nodes=nodes primary-section-alias=primarySectionAlias/>
-</else>

--- a/packages/global/components/flows/marko.json
+++ b/packages/global/components/flows/marko.json
@@ -47,6 +47,7 @@
   "<global-content-load-more-flow>": {
     "template": "./content-load-more.marko",
     "@nodes": "array",
+    "@primary-section-alias": "string",
     "@aliases": "array"
   },
   "<global-content-card-deck-flow>": {
@@ -61,6 +62,7 @@
       "default-value": 3
     },
     "@nodes": "array",
+    "@primary-section-alias": "string",
     "@aliases": "array",
     "@ad-index": "number",
     "@ad-name": "string",

--- a/packages/global/components/flows/marko.json
+++ b/packages/global/components/flows/marko.json
@@ -47,7 +47,7 @@
   "<global-content-load-more-flow>": {
     "template": "./content-load-more.marko",
     "@nodes": "array",
-    "@primary-section-alias": "string",
+    "@display-ads": "boolean",
     "@aliases": "array"
   },
   "<global-content-card-deck-flow>": {
@@ -57,12 +57,15 @@
       "@name": "string",
       "@aliases": "array"
     },
+    "@display-ads": {
+      "type": "boolean",
+      "default-value": true
+    },
     "@col": {
       "type": "number",
       "default-value": 3
     },
     "@nodes": "array",
-    "@primary-section-alias": "string",
     "@aliases": "array",
     "@ad-index": "number",
     "@ad-name": "string",

--- a/packages/global/components/nodes/content-list.marko
+++ b/packages/global/components/nodes/content-list.marko
@@ -32,7 +32,6 @@ $ const isUpcoming = content.startDate > Date.now();
     <@title tag="h5">
       <marko-web-content-short-name tag=null obj=content link={ attrs: linkAttrs } />
     </@title>
-    $ console.log(isWebinar, content.startDate, content.linkUrl)
     <@text modifiers=["teaser"] show=(withTeaser && content.teaser)>
       <marko-web-content-teaser tag=null obj=content link={ attrs: linkAttrs } />
     </@text>

--- a/packages/global/templates/content/index.marko
+++ b/packages/global/templates/content/index.marko
@@ -16,20 +16,22 @@ $ const displayVenueBox = ['article', 'media-gallery'].includes(type) ? true : f
     </marko-web-gtm-content-context>
     <marko-web-resolve-page|{ data: content }| node=pageNode>
       $ const aliases = hierarchyAliases(content.primarySection);
-      $ const adSlots = {
+      $ const adSlots = aliases.includes("sponsored") ? {} : {
         "gpt-ad-lb1": GAM.getAdUnit({ name: "lb1", aliases }),
         "gpt-ad-rail1": GAM.getAdUnit({ name: "rail1", aliases }),
         "gpt-ad-rail2": GAM.getAdUnit({ name: "rail2", aliases }),
       };
-      <marko-web-gam-slots slots=adSlots />
+        <marko-web-gam-slots slots=adSlots />
       <global-gam-content-targeting-element obj=content />
     </marko-web-resolve-page>
   </@head>
   <@above-container>
     <marko-web-resolve-page|{ data: content }| node=pageNode>
       $ const aliases = hierarchyAliases(content.primarySection);
-      <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "wa", aliases }) />
-      <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "reskin", aliases }) />
+      <if(!aliases.includes("sponsored"))>
+        <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "wa", aliases }) />
+        <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "reskin", aliases }) />
+      </if>
     </marko-web-resolve-page>
   </@above-container>
   <@page>
@@ -39,7 +41,7 @@ $ const displayVenueBox = ['article', 'media-gallery'].includes(type) ? true : f
       $ const aliases = hierarchyAliases(content.primarySection);
       <marko-web-page-wrapper>
         <@section>
-          <marko-web-gam-display-ad id="gpt-ad-lb1" />
+            <marko-web-gam-display-ad id="gpt-ad-lb1" />
         </@section>
         <@section>
           <div class="row">
@@ -145,7 +147,7 @@ $ const displayVenueBox = ['article', 'media-gallery'].includes(type) ? true : f
                 section-id=section.id
                 section-name=section.name
               />
-              <marko-web-gam-display-ad id="gpt-ad-rail2" />
+                <marko-web-gam-display-ad id="gpt-ad-rail2" />
             </aside>
           </div>
 

--- a/packages/global/templates/content/index.marko
+++ b/packages/global/templates/content/index.marko
@@ -16,7 +16,7 @@ $ const displayVenueBox = ['article', 'media-gallery'].includes(type) ? true : f
     </marko-web-gtm-content-context>
     <marko-web-resolve-page|{ data: content }| node=pageNode>
       $ const aliases = hierarchyAliases(content.primarySection);
-      $ const adSlots = aliases.includes("sponsored") ? {} : {
+      $ const adSlots = content.primarySection.alias === 'sponsored' ? {} : {
         "gpt-ad-lb1": GAM.getAdUnit({ name: "lb1", aliases }),
         "gpt-ad-rail1": GAM.getAdUnit({ name: "rail1", aliases }),
         "gpt-ad-rail2": GAM.getAdUnit({ name: "rail2", aliases }),
@@ -28,7 +28,7 @@ $ const displayVenueBox = ['article', 'media-gallery'].includes(type) ? true : f
   <@above-container>
     <marko-web-resolve-page|{ data: content }| node=pageNode>
       $ const aliases = hierarchyAliases(content.primarySection);
-      <if(!aliases.includes("sponsored"))>
+      <if(!content.primarySection.alias === 'sponsored')>
         <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "wa", aliases }) />
         <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "reskin", aliases }) />
       </if>
@@ -163,6 +163,7 @@ $ const displayVenueBox = ['article', 'media-gallery'].includes(type) ? true : f
         id=id
         type=type
         name=content.name
+        primary-section-alias=content.primarySection.alias
         aliases=aliases
         section-id=section.id
         section-name=section.name

--- a/packages/global/templates/content/index.marko
+++ b/packages/global/templates/content/index.marko
@@ -21,7 +21,7 @@ $ const displayVenueBox = ['article', 'media-gallery'].includes(type) ? true : f
         "gpt-ad-rail1": GAM.getAdUnit({ name: "rail1", aliases }),
         "gpt-ad-rail2": GAM.getAdUnit({ name: "rail2", aliases }),
       };
-        <marko-web-gam-slots slots=adSlots />
+      <marko-web-gam-slots slots=adSlots />
       <global-gam-content-targeting-element obj=content />
     </marko-web-resolve-page>
   </@head>
@@ -41,7 +41,7 @@ $ const displayVenueBox = ['article', 'media-gallery'].includes(type) ? true : f
       $ const aliases = hierarchyAliases(content.primarySection);
       <marko-web-page-wrapper>
         <@section>
-            <marko-web-gam-display-ad id="gpt-ad-lb1" />
+          <marko-web-gam-display-ad id="gpt-ad-lb1" />
         </@section>
         <@section>
           <div class="row">
@@ -147,7 +147,7 @@ $ const displayVenueBox = ['article', 'media-gallery'].includes(type) ? true : f
                 section-id=section.id
                 section-name=section.name
               />
-                <marko-web-gam-display-ad id="gpt-ad-rail2" />
+              <marko-web-gam-display-ad id="gpt-ad-rail2" />
             </aside>
           </div>
 

--- a/packages/global/templates/content/index.marko
+++ b/packages/global/templates/content/index.marko
@@ -163,7 +163,7 @@ $ const displayVenueBox = ['article', 'media-gallery'].includes(type) ? true : f
         id=id
         type=type
         name=content.name
-        primary-section-alias=content.primarySection.alias
+        display-ads=(content.primarySection.alias !== 'sponsored')
         aliases=aliases
         section-id=section.id
         section-name=section.name


### PR DESCRIPTION

<img width="1920" alt="Screen Shot 2021-07-08 at 3 17 54 PM" src="https://user-images.githubusercontent.com/46794001/124985385-f5e4d000-dfff-11eb-897e-1d0576230070.png">
<img width="1920" alt="Screen Shot 2021-07-08 at 3 19 35 PM" src="https://user-images.githubusercontent.com/46794001/124985393-f7ae9380-dfff-11eb-885f-648f60e2c8e5.png">
“Correct layout” = correct the load more section to query an additional piece of content so there are no gaps.