### PR TITLE
Update various published content pages.

### DIFF
--- a/packages/global/templates/published-content/podcasts.marko
+++ b/packages/global/templates/published-content/podcasts.marko
@@ -40,12 +40,12 @@ $ const description = defaultDescription(title, config);
         queryFragment,
       }
     >
-      <global-content-list-flow nodes=nodes />
+      <global-content-card-deck-flow nodes=nodes />
     </marko-web-query>
   </@page>
   <@below-page>
     <marko-web-load-more
-      component-name="content-list-flow"
+      component-name="content-load-more-flow"
       fragment-name="content-list"
       query-name="all-published-content"
       query-params={

--- a/packages/global/templates/published-content/webinars.marko
+++ b/packages/global/templates/published-content/webinars.marko
@@ -39,13 +39,7 @@ $ const bottomLeaderboard = {
       name="all-published-content"
       params={ contentTypes: ["Webinar"], sortField: "startDate", sortOrder: "desc", limit: 18, queryFragment }
     >
-      <global-content-list-flow
-        nodes=nodes
-        image-width=240
-        with-teaser=true
-        image-ar="3:2"
-        bottom-leaderboard=bottomLeaderboard
-      />
+      <global-content-card-deck-flow  nodes=nodes with-teaser=true bottom-leaderboard=bottomLeaderboard />
     </marko-web-query>
   </@page>
   <@below-page>
@@ -54,11 +48,8 @@ $ const bottomLeaderboard = {
       modifiers: ["load-more"]
     };
     <marko-web-load-more
-      component-name="content-list-flow"
+      component-name="content-load-more-flow"
       component-input= {
-        imagePosition: "left",
-        imageWidth: 240,
-        imageAr: "3:2",
         withTeaser: true,
         bottomLeaderboard,
       }

--- a/packages/global/templates/published-content/white-papers.marko
+++ b/packages/global/templates/published-content/white-papers.marko
@@ -37,13 +37,7 @@ $ const bottomLeaderboard = {
       name="all-published-content"
       params={ contentTypes: ["Whitepaper"], limit: 18, queryFragment }
     >
-      <global-content-list-flow
-        nodes=nodes
-        image-width=240
-        with-teaser=true
-        image-ar="3:2"
-        bottom-leaderboard=bottomLeaderboard
-      />
+      <global-content-card-deck-flow nodes=nodes with-teaser=true bottom-leaderboard=bottomLeaderboard />
     </marko-web-query>
   </@page>
   <@below-page>
@@ -52,14 +46,8 @@ $ const bottomLeaderboard = {
       modifiers: ["load-more"]
     };
     <marko-web-load-more
-      component-name="content-list-flow"
-      component-input= {
-        imagePosition: "left",
-        imageWidth: 240,
-        imageAr: "3:2",
-        withTeaser: true,
-        bottomLeaderboard,
-      }
+      component-name="content-load-more-flow"
+      component-input={ withTeaser: true, bottomLeaderboard }
       fragment-name="content-list"
       query-name="all-published-content"
       query-params={ contentTypes: ["Whitepaper"], limit: 18, skip: 18 }

--- a/sites/bizbash.com/server/templates/website-section/gathergeeks.marko
+++ b/sites/bizbash.com/server/templates/website-section/gathergeeks.marko
@@ -42,14 +42,7 @@ $ const { id, alias, name, pageNode } = data;
         name="website-scheduled-content"
         params={ sectionId: id, limit: 12, requiresImage: true, queryFragment }
       >
-        <global-content-list-flow
-          inner-justified=true
-          nodes=nodes
-          with-teaser=true
-          image-ar="16:9"
-          image-width=340
-          image-position='left'
-        />
+    <global-content-card-deck-flow nodes=nodes />
       </marko-web-query>
     </marko-web-resolve-page>
   </@page>
@@ -58,14 +51,8 @@ $ const { id, alias, name, pageNode } = data;
     <marko-web-resolve-page|{ data: section }| node=pageNode>
       $ const aliases = hierarchyAliases(section);
       <marko-web-load-more
-        component-name="content-list-flow"
-        component-input={
-          aliases,
-          withTeaser: true,
-          imageAr: "16:9",
-          imageWidth: 340,
-          imagePosition: 'left'
-        }
+        component-name="content-load-more-flow"
+        component-input={ aliases, bottomLeaderboard: true }
         fragment-name="content-list"
         query-name="website-scheduled-content"
         query-params={ sectionId: id, limit: 12, skip: 12, requiresImage: true }


### PR DESCRIPTION

<img width="1920" alt="Screen Shot 2021-07-28 at 2 54 16 PM" src="https://user-images.githubusercontent.com/46794001/127387220-a3016837-6610-4421-a357-972b9d922707.png">
<img width="1920" alt="Screen Shot 2021-07-28 at 2 54 28 PM" src="https://user-images.githubusercontent.com/46794001/127387226-3f272337-b62f-4102-81e3-c3811a06e301.png">
<img width="1920" alt="Screen Shot 2021-07-28 at 2 54 38 PM" src="https://user-images.githubusercontent.com/46794001/127387228-551f05fe-3597-40c4-9017-352ef7c375ea.png">
<img width="1920" alt="Screen Shot 2021-07-28 at 2 54 49 PM" src="https://user-images.githubusercontent.com/46794001/127387232-d4cd57b8-2dee-4346-992e-e1647c68af7d.png">
These now use the "top picture block" item format like much of the other content pages.