### PR TITLE
Adjust line-height on nav items, prevent cutoff.

### DIFF
--- a/packages/global/scss/index.scss
+++ b/packages/global/scss/index.scss
@@ -155,7 +155,7 @@ $theme-site-navbar-secondary-font-size:     14px;
 $theme-site-navbar-secondary-font-size-sm:  12px;
 $theme-site-navbar-secondary-font-family:   $font-source-sans-pro;
 $theme-site-navbar-secondary-font-weight:   600;
-$theme-site-navbar-secondary-line-height:   1;
+$theme-site-navbar-secondary-line-height:   1.25;
 
 $theme-site-navbar-secondary-link-active-color:       $black;
 $theme-site-navbar-secondary-link-active-decoration:  none;


### PR DESCRIPTION
BEFORE:
<img width="1920" alt="Screen Shot 2021-07-29 at 2 16 45 PM" src="https://user-images.githubusercontent.com/46794001/127552861-3fc728e1-c930-4a81-bc79-c829d1812151.png">

AFTER:
<img width="1920" alt="Screen Shot 2021-07-29 at 2 15 48 PM" src="https://user-images.githubusercontent.com/46794001/127552864-433daf91-de7e-48d8-8118-7a4a8e9f8c65.png">


See comment on attached Trello card.