### PR TITLE
Update font weight on published content page cards

### DIFF
--- a/packages/global/components/flows/content-card-deck.marko
+++ b/packages/global/components/flows/content-card-deck.marko
@@ -2,7 +2,7 @@ import { getAsArray, getAsObject } from "@parameter1/base-cms-object-path";
 
 $ const { site, GAM } = out.global;
 $ const nxConfig = site.get('nativeX');
-$ const { aliases, adIndex, adName, bottomLeaderboard, col, displayImage, withTeaser }  = input;
+$ const { aliases, adIndex, adName, bottomLeaderboard, col, displayImage, withTeaser, titleModifiers }  = input;
 $ const nodes = getAsArray(input, "nodes");
 $ const nativeX = getAsObject(input, "nativeX");
 $ const adPosition = input.adPosition || "after";
@@ -23,6 +23,7 @@ $ const adPosition = input.adPosition || "after";
           node=nxNode
           attrs=containerAttrs
           link-attrs=linkAttrs
+          title-modifiers=titleModifiers
         />
       </marko-web-native-x-render>
     </@slot>

--- a/packages/global/components/flows/content-load-more.marko
+++ b/packages/global/components/flows/content-load-more.marko
@@ -6,6 +6,7 @@ $ const { GAM } = out.global;
 $ const {
   aliases,
   bottomLeaderboard,
+  titleModifiers
 } = input;
 $ const nodes = getAsArray(input, "nodes");
 $ const displayAds = defaultValue(input.displayAds, true);
@@ -20,11 +21,11 @@ $ const adName = "load-more";
 
     <!-- Card Deck flow with 300x250 in ad slot 4 -->
     <if(nodes1.length)>
-      <global-content-card-deck-flow nodes=nodes1 ad-index=4 ad-name=adName />
+      <global-content-card-deck-flow nodes=nodes1 ad-index=4 ad-name=adName title-modifiers=titleModifiers />
     </if>
 
     <if(nodes2.length)>
-      <global-content-card-deck-flow nodes=nodes2 ad-index=2 ad-name=adName />
+      <global-content-card-deck-flow nodes=nodes2 ad-index=2 ad-name=adName title-modifiers=titleModifiers />
     </if>
 
     <if(nodes3.length)>
@@ -33,13 +34,13 @@ $ const adName = "load-more";
           <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: adName, size: [300, 600], aliases }) modifiers=["in-card"] />
         </div>
         <div class="col-lg-8">
-          <global-content-card-deck-flow col=2 nodes=nodes3 />
+          <global-content-card-deck-flow col=2 nodes=nodes3 title-modifiers=titleModifiers />
         </div>
       </div>
     </if>
 
     <if(nodes4.length)>
-      <global-content-card-deck-flow nodes=nodes4 />
+      <global-content-card-deck-flow nodes=nodes4 title-modifiers=titleModifiers />
     </if>
     <if(bottomLeaderboard)>
       <marko-web-gam-define-display-ad ...bottomLeaderboard />

--- a/packages/global/components/flows/marko.json
+++ b/packages/global/components/flows/marko.json
@@ -48,7 +48,8 @@
     "template": "./content-load-more.marko",
     "@nodes": "array",
     "@display-ads": "boolean",
-    "@aliases": "array"
+    "@aliases": "array",
+    "@title-modifiers": "array"
   },
   "<global-content-card-deck-flow>": {
     "template": "./content-card-deck.marko",
@@ -78,7 +79,8 @@
       "type": "boolean",
       "default-value": false
     },
-    "@bottom-leaderboard": "object"
+    "@bottom-leaderboard": "object",
+    "@title-modifiers": "array"
   },
   "<global-magazine-issue-archive-flow>": {
     "template": "./magazine-issue-archive.marko",

--- a/packages/global/scss/index.scss
+++ b/packages/global/scss/index.scss
@@ -377,7 +377,7 @@ $theme-site-header-breakpoints: map-merge(
   .node {
     .node {
       &__title {
-        &--published {
+        &--bold {
           font-weight: 700;
         }
       }

--- a/packages/global/scss/index.scss
+++ b/packages/global/scss/index.scss
@@ -375,6 +375,13 @@ $theme-site-header-breakpoints: map-merge(
 }
 .card-deck-flow {
   .node {
+    .node {
+      &__title {
+        &--published {
+          font-weight: 700;
+        }
+      }
+    }
     &--no-image-overlay {
       height: 100%;
       box-shadow: 0 2px 8px rgba(0, 0, 0, .15);

--- a/packages/global/scss/index.scss
+++ b/packages/global/scss/index.scss
@@ -375,11 +375,9 @@ $theme-site-header-breakpoints: map-merge(
 }
 .card-deck-flow {
   .node {
-    .node {
-      &__title {
-        &--bold {
-          font-weight: 700;
-        }
+    &__title {
+      &--bold {
+        font-weight: 700;
       }
     }
     &--no-image-overlay {

--- a/packages/global/templates/published-content/podcasts.marko
+++ b/packages/global/templates/published-content/podcasts.marko
@@ -40,12 +40,15 @@ $ const description = defaultDescription(title, config);
         queryFragment,
       }
     >
-      <global-content-card-deck-flow nodes=nodes />
+      <global-content-card-deck-flow nodes=nodes title-modifiers=["published"] />
     </marko-web-query>
   </@page>
   <@below-page>
     <marko-web-load-more
       component-name="content-load-more-flow"
+      component-input={
+        titleModifiers: ["published"]
+      }
       fragment-name="content-list"
       query-name="all-published-content"
       query-params={

--- a/packages/global/templates/published-content/podcasts.marko
+++ b/packages/global/templates/published-content/podcasts.marko
@@ -40,14 +40,14 @@ $ const description = defaultDescription(title, config);
         queryFragment,
       }
     >
-      <global-content-card-deck-flow nodes=nodes title-modifiers=["published"] />
+      <global-content-card-deck-flow nodes=nodes title-modifiers=["bold"] />
     </marko-web-query>
   </@page>
   <@below-page>
     <marko-web-load-more
       component-name="content-load-more-flow"
       component-input={
-        titleModifiers: ["published"]
+        titleModifiers: ["bold"]
       }
       fragment-name="content-list"
       query-name="all-published-content"

--- a/packages/global/templates/published-content/webinars.marko
+++ b/packages/global/templates/published-content/webinars.marko
@@ -39,7 +39,7 @@ $ const bottomLeaderboard = {
       name="all-published-content"
       params={ contentTypes: ["Webinar"], sortField: "startDate", sortOrder: "desc", limit: 18, queryFragment }
     >
-      <global-content-card-deck-flow  nodes=nodes with-teaser=true bottom-leaderboard=bottomLeaderboard title-modifiers=["published"] />
+      <global-content-card-deck-flow  nodes=nodes with-teaser=true bottom-leaderboard=bottomLeaderboard title-modifiers=["bold"] />
     </marko-web-query>
   </@page>
   <@below-page>
@@ -50,7 +50,7 @@ $ const bottomLeaderboard = {
     <marko-web-load-more
       component-name="content-load-more-flow"
       component-input= {
-        titleModifiers: ["published"],
+        titleModifiers: ["bold"],
         withTeaser: true,
         bottomLeaderboard,
       }

--- a/packages/global/templates/published-content/webinars.marko
+++ b/packages/global/templates/published-content/webinars.marko
@@ -39,7 +39,7 @@ $ const bottomLeaderboard = {
       name="all-published-content"
       params={ contentTypes: ["Webinar"], sortField: "startDate", sortOrder: "desc", limit: 18, queryFragment }
     >
-      <global-content-card-deck-flow  nodes=nodes with-teaser=true bottom-leaderboard=bottomLeaderboard />
+      <global-content-card-deck-flow  nodes=nodes with-teaser=true bottom-leaderboard=bottomLeaderboard title-modifiers=["published"] />
     </marko-web-query>
   </@page>
   <@below-page>
@@ -50,6 +50,7 @@ $ const bottomLeaderboard = {
     <marko-web-load-more
       component-name="content-load-more-flow"
       component-input= {
+        titleModifiers: ["published"],
         withTeaser: true,
         bottomLeaderboard,
       }

--- a/packages/global/templates/published-content/white-papers.marko
+++ b/packages/global/templates/published-content/white-papers.marko
@@ -37,7 +37,7 @@ $ const bottomLeaderboard = {
       name="all-published-content"
       params={ contentTypes: ["Whitepaper"], limit: 18, queryFragment }
     >
-      <global-content-card-deck-flow nodes=nodes with-teaser=true bottom-leaderboard=bottomLeaderboard title-modifiers=["published"] />
+      <global-content-card-deck-flow nodes=nodes with-teaser=true bottom-leaderboard=bottomLeaderboard title-modifiers=["bold"] />
     </marko-web-query>
   </@page>
   <@below-page>
@@ -48,7 +48,7 @@ $ const bottomLeaderboard = {
     <marko-web-load-more
       component-name="content-load-more-flow"
       component-input={
-        titleModifiers: ["published"],
+        titleModifiers: ["bold"],
         withTeaser: true,
         bottomLeaderboard
       }

--- a/packages/global/templates/published-content/white-papers.marko
+++ b/packages/global/templates/published-content/white-papers.marko
@@ -37,7 +37,7 @@ $ const bottomLeaderboard = {
       name="all-published-content"
       params={ contentTypes: ["Whitepaper"], limit: 18, queryFragment }
     >
-      <global-content-card-deck-flow nodes=nodes with-teaser=true bottom-leaderboard=bottomLeaderboard />
+      <global-content-card-deck-flow nodes=nodes with-teaser=true bottom-leaderboard=bottomLeaderboard title-modifiers=["published"] />
     </marko-web-query>
   </@page>
   <@below-page>
@@ -47,7 +47,11 @@ $ const bottomLeaderboard = {
     };
     <marko-web-load-more
       component-name="content-load-more-flow"
-      component-input={ withTeaser: true, bottomLeaderboard }
+      component-input={
+        titleModifiers: ["published"],
+        withTeaser: true,
+        bottomLeaderboard
+      }
       fragment-name="content-list"
       query-name="all-published-content"
       query-params={ contentTypes: ["Whitepaper"], limit: 18, skip: 18 }

--- a/sites/bizbash.com/server/templates/website-section/gathergeeks.marko
+++ b/sites/bizbash.com/server/templates/website-section/gathergeeks.marko
@@ -42,7 +42,7 @@ $ const { id, alias, name, pageNode } = data;
         name="website-scheduled-content"
         params={ sectionId: id, limit: 12, requiresImage: true, queryFragment }
       >
-    <global-content-card-deck-flow nodes=nodes title-modifiers=["published"] />
+    <global-content-card-deck-flow nodes=nodes title-modifiers=["bold"] />
       </marko-web-query>
     </marko-web-resolve-page>
   </@page>
@@ -53,7 +53,7 @@ $ const { id, alias, name, pageNode } = data;
       <marko-web-load-more
         component-name="content-load-more-flow"
         component-input={
-          titleModifiers: ["published"],
+          titleModifiers: ["bold"],
           aliases,
           bottomLeaderboard: true,
         }

--- a/sites/bizbash.com/server/templates/website-section/gathergeeks.marko
+++ b/sites/bizbash.com/server/templates/website-section/gathergeeks.marko
@@ -42,7 +42,7 @@ $ const { id, alias, name, pageNode } = data;
         name="website-scheduled-content"
         params={ sectionId: id, limit: 12, requiresImage: true, queryFragment }
       >
-    <global-content-card-deck-flow nodes=nodes />
+    <global-content-card-deck-flow nodes=nodes title-modifiers=["published"] />
       </marko-web-query>
     </marko-web-resolve-page>
   </@page>
@@ -52,10 +52,14 @@ $ const { id, alias, name, pageNode } = data;
       $ const aliases = hierarchyAliases(section);
       <marko-web-load-more
         component-name="content-load-more-flow"
-        component-input={ aliases, bottomLeaderboard: true }
+        component-input={
+          titleModifiers: ["published"],
+          aliases,
+          bottomLeaderboard: true,
+        }
         fragment-name="content-list"
         query-name="website-scheduled-content"
-        query-params={ sectionId: id, limit: 12, skip: 12, requiresImage: true }
+        query-params={ sectionId: id, limit: 14, skip: 12, requiresImage: true }
         page-input={ for: "website-section", id }
       />
     </marko-web-resolve-page>


### PR DESCRIPTION
This also has a fix for the gather geeks page not filling the load more section out fully

BEFORE: 
<img width="1920" alt="Screen Shot 2021-07-30 at 9 31 24 AM" src="https://user-images.githubusercontent.com/46794001/127668718-67d0a696-f040-4cdc-a3d9-f81a59fa0dca.png">
<img width="1917" alt="Screen Shot 2021-07-30 at 9 31 36 AM" src="https://user-images.githubusercontent.com/46794001/127668729-7919729d-41ed-4cfa-8bdb-289856b7c531.png">
<img width="1920" alt="Screen Shot 2021-07-30 at 9 31 44 AM" src="https://user-images.githubusercontent.com/46794001/127668736-d3e88d9b-a46c-48aa-9b7e-bf1a5a057f76.png">
<img width="1920" alt="Screen Shot 2021-07-30 at 9 31 53 AM" src="https://user-images.githubusercontent.com/46794001/127668742-14d2e3d3-b963-4e1f-83e8-4132f7e892ab.png">
<img width="1920" alt="Screen Shot 2021-07-30 at 9 32 17 AM" src="https://user-images.githubusercontent.com/46794001/127668744-7bffec8f-9cb3-4ec0-b4e9-e0dc78944514.png">

AFTER:
<img width="1920" alt="Screen Shot 2021-07-30 at 9 32 35 AM" src="https://user-images.githubusercontent.com/46794001/127668771-f24d53c3-9184-44dd-947e-8f784e0e870e.png">
<img width="1920" alt="Screen Shot 2021-07-30 at 9 32 43 AM" src="https://user-images.githubusercontent.com/46794001/127668776-6d6eb7f6-b542-4621-b108-bb9307f46e7e.png">
<img width="1920" alt="Screen Shot 2021-07-30 at 9 32 52 AM" src="https://user-images.githubusercontent.com/46794001/127668781-0d8a784b-f9f3-4746-a43a-a34a7b1ac3ef.png">
<img width="1920" alt="Screen Shot 2021-07-30 at 9 32 58 AM" src="https://user-images.githubusercontent.com/46794001/127668873-287e6dfe-e376-44be-a0d2-6038e7c17a77.png">
<img width="1920" alt="Screen Shot 2021-07-30 at 9 33 09 AM" src="https://user-images.githubusercontent.com/46794001/127668885-8d3720d8-1e29-457f-bde0-67c57bd1c18d.png">
