### PR TITLE
Setup native-x to occupy requested slot

### DIFF
--- a/packages/global/components/flows/content-load-more.marko
+++ b/packages/global/components/flows/content-load-more.marko
@@ -21,7 +21,7 @@ $ const adName = "load-more";
 
     <!-- Card Deck flow with 300x250 in ad slot 4 -->
     <if(nodes1.length)>
-      <global-content-card-deck-flow nodes=nodes1 ad-index=4 ad-name=adName title-modifiers=titleModifiers />
+      <global-content-card-deck-flow nodes=nodes1 ad-index=4 ad-name=adName title-modifiers=titleModifiers native-x={ index: 0, name: "primary" } />
     </if>
 
     <if(nodes2.length)>

--- a/packages/global/components/nodes/content-card.marko
+++ b/packages/global/components/nodes/content-card.marko
@@ -38,7 +38,9 @@ $ const { linkAttrs } = input;
         <marko-web-website-section-name obj=primarySection link=true />
       </@left>
       <@right|{ blockName }|>
+      <if(content.type !== 'text-ad')>
         <dates block-name=blockName content=content />
+      </if>
       </@right>
     </@footer>
   </@body>

--- a/packages/global/scss/index.scss
+++ b/packages/global/scss/index.scss
@@ -577,6 +577,10 @@ body {
     }
   }
 
+  &__footer-left {
+    color: $primary;
+  }
+
   &__footer-right {
     white-space: nowrap;
   }

--- a/sites/bizbash.com/config/native-x.js
+++ b/sites/bizbash.com/config/native-x.js
@@ -9,9 +9,6 @@ config
   .setAliasPlacements('catering-design', [
     { name: 'primary', id: '5d4b04513bb2db00018cfa1a' },
   ])
-  .setAliasPlacements('style-decor', [
-    { name: 'primary', id: '5d4b04619f69b200013ab0f4' },
-  ])
   .setAliasPlacements('production-strategy', [
     { name: 'primary', id: '5d4b04769f69b200013ab109' },
   ])


### PR DESCRIPTION

<img width="1920" alt="Screen Shot 2021-08-02 at 1 50 44 PM" src="https://user-images.githubusercontent.com/46794001/127909606-f549ab00-318e-495b-9987-121cf81510c1.png">
<img width="1920" alt="Screen Shot 2021-08-02 at 1 44 28 PM" src="https://user-images.githubusercontent.com/46794001/127909197-36973e83-d773-4db1-9d91-18ee68c2970a.png">


It appears Native-X was set up for this site at some point but nothing was actually declaring an index to put them anywhere, this puts it as the first card in all load-more sections for both landing and content pages. Should this need to get moved up a level to only be on section landings let me know.