### PR TITLE
Increase secondary nav font size by 1pt (2px)

### DIFF
--- a/packages/global/scss/index.scss
+++ b/packages/global/scss/index.scss
@@ -151,7 +151,7 @@ $theme-site-navbar-primary-link-color:              $white;
 $theme-site-navbar-primary-link-hover-color:        $black;
 
 $theme-site-navbar-secondary-bg-color:      $primary;
-$theme-site-navbar-secondary-font-size:     14px;
+$theme-site-navbar-secondary-font-size:     16px;
 $theme-site-navbar-secondary-font-size-sm:  12px;
 $theme-site-navbar-secondary-font-family:   $font-source-sans-pro;
 $theme-site-navbar-secondary-font-weight:   600;


### PR DESCRIPTION
I looked up the conversion 1pt = 1.33 repeating of course px.

BEFORE:
![Screen Shot 2021-08-06 at 9 07 59 AM](https://user-images.githubusercontent.com/46794001/128523353-ddc9e373-5013-4aa6-b830-13d8d801491d.png)

AFTER:
![Screen Shot 2021-08-06 at 9 09 45 AM](https://user-images.githubusercontent.com/46794001/128523370-987214f5-53ad-4641-85fa-4cb5edd51534.png)
