### PR TITLE
Update preview size and gate verbiage for podcasts

### DIFF
--- a/packages/global/components/blocks/content-page/gate.marko
+++ b/packages/global/components/blocks/content-page/gate.marko
@@ -12,7 +12,7 @@ $ const {
   requiresUserInput,
 } = input;
 $ const messages = getAsObject(input, "messages");
-$ const title = defaultValue(input.title, "Log in to view the full article");
+$ const title = defaultValue(input.title, "Enter you email address for full access");
 $ const userInputTitle = defaultValue(input.userInputTitle, "Complete your profile to view the full article");
 
 <marko-web-block name=blockName>

--- a/packages/global/components/blocks/content-page/gate.marko
+++ b/packages/global/components/blocks/content-page/gate.marko
@@ -12,7 +12,7 @@ $ const {
   requiresUserInput,
 } = input;
 $ const messages = getAsObject(input, "messages");
-$ const title = defaultValue(input.title, "Enter you email address for full access");
+$ const title = defaultValue(input.title, "Enter your email address for full access");
 $ const userInputTitle = defaultValue(input.userInputTitle, "Complete your profile to view the full article");
 
 <marko-web-block name=blockName>

--- a/packages/global/templates/content/index.marko
+++ b/packages/global/templates/content/index.marko
@@ -87,7 +87,9 @@ $ const sectionsWithoutAds = [];
                 required-access-level-ids=accessLevels
               >
                 <if(!context.canAccess || context.requiresUserInput)>
-                  $ const body = getContentPreview({ body: content.body, selector: "p:nth-of-type(1)" });
+                  $ const defaultPreview = getContentPreview({ body: content.body, selector: "p:nth-of-type(1)" });
+                  $ const podcastPreview = getContentPreview({ body: content.body, selector: "p:nth-of-type(-n+2)" });
+                  $ const body = content.type === "podcast" ? podcastPreview : defaultPreview
                   <marko-web-content-body block-name=blockName obj={ body } />
 
                   <div class="content-page-preview-overlay" />


### PR DESCRIPTION
<img width="1920" alt="Screen Shot 2021-08-26 at 9 41 58 AM" src="https://user-images.githubusercontent.com/46794001/131343329-a8c44ebc-5940-44e0-b6ee-e8a71878c5f1.png">


I can't figure out how to log out of Identity-X so this was the best screenshot I had on hand for this.