### PR TITLE
Vertically align video ad on desktop and tablet.

### DIFF
--- a/packages/global/components/blocks/webinars-podcasts.marko
+++ b/packages/global/components/blocks/webinars-podcasts.marko
@@ -20,15 +20,15 @@ $ const { GAM } = out.global;
   </marko-web-link>
 </marko-web-element>
 <div class="row my-block">
-  <div class="col-sm-1 col-md-6 col-lg-4 my-md-block">
+  <div class="col-sm-12 col-md-6 col-lg-4 my-md-block">
     <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "vid", aliases: ['home'] }) modifiers=["no-shadow"] />
   </div>
-  <div class="col-sm-1 col-md-6 col-lg-4">
+  <div class="col-sm-12 col-md-6 col-lg-4">
     <marko-web-query|{ nodes }| name="all-published-content" params={ contentTypes: ["Webinar"], limit: 1, queryFragment }>
       <global-content-card-node node=nodes[0] display-image=input.displayImage title-modifiers=["small"] />
     </marko-web-query>
   </div>
-  <div class="col-sm-1 col-md-6 col-lg-4">
+  <div class="col-sm-12 col-md-6 col-lg-4">
     <marko-web-query|{nodes, section }| name="website-scheduled-content" params=queryParams>
       <global-content-card-node node=nodes[0] display-image=input.displayImage title-modifiers=["small"] />
     </marko-web-query>

--- a/packages/global/components/blocks/webinars-podcasts.marko
+++ b/packages/global/components/blocks/webinars-podcasts.marko
@@ -20,7 +20,7 @@ $ const { GAM } = out.global;
   </marko-web-link>
 </marko-web-element>
 <div class="row my-block">
-  <div class="col-sm-1 col-md-6 col-lg-4">
+  <div class="col-sm-1 col-md-6 col-lg-4 my-md-block">
     <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "vid", aliases: ['home'] }) modifiers=["no-shadow"] />
   </div>
   <div class="col-sm-1 col-md-6 col-lg-4">


### PR DESCRIPTION
Mobile (Phone Size):
<img width="444" alt="Screen Shot 2022-02-02 at 9 51 26 AM" src="https://user-images.githubusercontent.com/46794001/152189088-c02ead77-5a7c-4215-a9de-d1a34b695298.png">

Tablet:
<img width="548" alt="Screen Shot 2022-02-02 at 9 52 50 AM" src="https://user-images.githubusercontent.com/46794001/152189141-9eafc075-26e6-4a6b-b654-13cde06c4515.png">

Desktop:
<img width="1920" alt="Screen Shot 2022-02-02 at 9 53 02 AM" src="https://user-images.githubusercontent.com/46794001/152189177-ff5f0c6d-0d52-4b72-a906-388b2018d2e6.png">

