### PR TITLE
Add Sport Events + rail ad to Production and Strategy section lists.

### DIFF
--- a/sites/bizbash.com/config/sectionListLayouts.js
+++ b/sites/bizbash.com/config/sectionListLayouts.js
@@ -48,9 +48,11 @@ module.exports = {
     { alias: 'event-management', name: 'Event Management' },
     { alias: 'event-production-fabrication', name: 'Event Production & Fabrication' },
     { alias: 'opinion-experts', name: 'Opinion & Experts' },
+    { adId: 'gpt-ad-rail1' },
     { alias: 'programming-entertainment', name: 'Programming & Entertainment' },
     { alias: 'registration-ticketing', name: 'Registration & Ticketing' },
     { alias: 'social-events', name: 'Social Events' },
     { alias: 'strategy', name: 'Strategy' },
+    { alias: 'sports-events', name: 'Sports Events' },
   ],
 };


### PR DESCRIPTION
<img width="1918" alt="Screen Shot 2022-04-06 at 2 16 49 PM" src="https://user-images.githubusercontent.com/46794001/162051983-dc57126d-1659-4e20-84a7-9d961d736437.png">
