### PR TITLE
Sort events by start date on Events page.

### DIFF
--- a/packages/global/templates/published-content/events.marko
+++ b/packages/global/templates/published-content/events.marko
@@ -35,8 +35,13 @@ $ const bottomLeaderboard = {
 
     <marko-web-query|{ nodes }|
       name="all-published-content"
-      params={ contentTypes: ["Event"], limit: 18, queryFragment }
-    >
+      params={
+        contentTypes: ["Event"],
+        sortField: "startDate",
+        sortOrder: "asc",
+        limit: 18,
+        queryFragment
+      }>
       <global-content-card-deck-flow nodes=nodes with-teaser=true bottom-leaderboard=bottomLeaderboard title-modifiers=["bold"] />
     </marko-web-query>
   </@page>
@@ -54,7 +59,13 @@ $ const bottomLeaderboard = {
       }
       fragment-name="content-list"
       query-name="all-published-content"
-      query-params={ contentTypes: ["Event"], limit: 18, skip: 18 }
+      query-params={
+        contentTypes: ["Event"],
+        sortField: "startDate",
+        sortOrder: "asc",
+        limit: 18,
+        skip: 18
+      }
       page-input={ for: "published-content" }
     />
   </@below-page>


### PR DESCRIPTION
<img width="1920" alt="Screen Shot 2022-05-10 at 9 39 12 AM" src="https://user-images.githubusercontent.com/46794001/167655518-518f41b9-0fd4-4330-9525-913042fcfe54.png">
