### PR TITLE
Add content images display to default layout for use on media gallery content type

### DIFF
--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -71,6 +71,7 @@ $ const shouldInjectAds = ["article", "blog", "video", "media-gallery", "news", 
               <marko-web-content-embed-code block-name=blockName obj=iframeContent />
             </if>
             <else-if(type === "media-gallery")>
+              <!-- <marko-web-image-slider images=images /> -->
             </else-if>
             <else-if(displayPrimaryImage)>
               $ let forceDisplay;

--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -71,7 +71,6 @@ $ const shouldInjectAds = ["article", "blog", "video", "media-gallery", "news", 
               <marko-web-content-embed-code block-name=blockName obj=iframeContent />
             </if>
             <else-if(type === "media-gallery")>
-              <!-- <marko-web-image-slider images=images /> -->
             </else-if>
             <else-if(displayPrimaryImage)>
               $ let forceDisplay;
@@ -198,6 +197,19 @@ $ const shouldInjectAds = ["article", "blog", "video", "media-gallery", "news", 
                       <marko-web-content-body obj=author block-name="inline-author-bio" />
                     </if>
                   </for>
+                </if>
+
+                <if(type === "media-gallery")>
+                  $ const images = getAsArray(content, 'images.edges').map(({ node }) => node);
+                  <if(images.length)>
+                    <div class="page-contents__images">
+                      <for|image, index| of=images>
+                        <div id=`image-${image.id}`>
+                          <theme-primary-image-block block-name="gallery-image" obj=image />
+                        </div>
+                      </for>
+                    </div>
+                  </if>
                 </if>
 
                 <if(displayReadNext)>

--- a/packages/global/scss/components/_content-images.scss
+++ b/packages/global/scss/components/_content-images.scss
@@ -1,0 +1,16 @@
+.page-contents__images {
+  .primary-image {
+    border-bottom: solid 1px $gray-800;
+    margin-bottom: map-get($spacers, block);
+    &__wrapper {
+      margin-top: map-get($spacers, 2);
+      margin-bottom: map-get($spacers, 2);
+    }
+    &__image-display-name {
+      font-weight: $font-weight-bold;
+    }
+    &__image-credit {
+      display: block;
+    }
+  }
+}

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -22,6 +22,7 @@
 @import "./components/section-feed-upcoming";
 @import "./components/content-meter";
 @import "./components/directory-section-feed";
+@import "./components/content-images";
 @import "./components/site-footer";
 @import "./components/site-navbar";
 @import "./components/site-navbar-c";


### PR DESCRIPTION
Currently this will only be used on mediaGallery content types.

![gallery](https://user-images.githubusercontent.com/3845869/208759745-91a104f7-1fda-4e26-b833-62b3b93f38d2.jpg)
