### PR TITLE
Add all-published-content template/layout/route support

### DIFF
--- a/packages/global/components/layouts/website-section/all-published-feed.marko
+++ b/packages/global/components/layouts/website-section/all-published-feed.marko
@@ -1,0 +1,97 @@
+import queryFragment from "@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/section-feed-block";
+
+import { getAsArray } from "@parameter1/base-cms-object-path";
+
+$ const {
+  alias,
+  name,
+  withAds,
+  description,
+} = input;
+
+$ const type = input.type || "published-content";
+$ const sections = getAsArray(input, "sections");
+
+$ const { pagination: p, GAM } = out.global;
+$ const perPage = 12;
+$ const aliases = [alias];
+$ const queryParams = {
+  queryFragment,
+  ...input.queryParams,
+}
+
+<theme-default-page
+  alias=alias
+  type=type
+  name=name
+  description=description
+>
+  <@head>
+    <theme-section-feed-block|{ totalCount }| count-only=true query-name="all-published-content">
+      <@query-params ...queryParams />
+      <theme-pagination-controls
+        per-page=perPage
+        total-count=totalCount
+        as-rels=true
+      />
+    </theme-section-feed-block>
+  </@head>
+  <if(GAM.enableRevealAd)>
+    <@above-container>
+      <theme-reveal-ad-handler select-all-targets=true path=GAM.getAdUnit({ name: "reskin", aliases: [alias] }).path id="reveal-ad" />
+    </@above-container>
+  </if>
+  <@page>
+    <marko-web-page-wrapper>
+      <@section modifiers=["first-sm"]>
+        <theme-gam-define-display-ad
+          name="leaderboard"
+          position="section_page"
+          aliases=[alias]
+          modifiers=["inter-block"]
+        />
+      </@section>
+
+      <@section|{ blockName }|>
+        <if(input.beforeName)>
+          <${input.beforeName}
+            aliases=aliases
+            block-name=blockName
+            section=section
+          />
+        </if>
+        <marko-web-website-section-name|{ value }| tag="h1" block-name=blockName obj={ name, description }>
+          <if(p.page > 1)>${value}: Page ${p.page}</if>
+          <else>${value}</else>
+        </marko-web-website-section-name>
+        <if(input.afterName)>
+          <${input.afterName}
+            aliases=aliases
+            block-name=blockName
+            section=section
+          />
+        </if>
+
+        <if(description)>
+          <marko-web-element class="page-wrapper__description">
+            $!{description}
+          </marko-web-element>
+        </if>
+
+
+        <global-section-feed-wrapper query-name="all-published-content" aliases=[alias] alias=alias modifiers=["all-published"] with-ads=withAds>
+          <@query-params ...queryParams />
+        </global-section-feed-wrapper>
+      </@section>
+
+      <for|s| of=sections>
+        <@section|{ blockName }| modifiers=s.modifiers>
+          <${s.renderBody}
+            block-name=blockName
+            aliases=aliases
+          />
+        </@section>
+      </for>
+    </marko-web-page-wrapper>
+  </@page>
+</theme-default-page>

--- a/packages/global/components/layouts/website-section/marko.json
+++ b/packages/global/components/layouts/website-section/marko.json
@@ -19,6 +19,17 @@
     "@page-node": "object",
     "@with-ads": "boolean"
   },
+  "<global-all-published-content-feed-layout>": {
+    "template": "./all-published-feed.marko",
+    "@alias": "string",
+    "@sections <section>[]": {},
+    "<before-name>": {},
+    "<after-name>": {},
+    "@description": "string",
+    "@name": "string",
+    "@with-ads": "boolean",
+    "@query-params": "object"
+  },
   "<global-website-section-upcoming-feed-layout>": {
     "template": "./upcoming-feed.marko",
     "@sections <section>[]": {},

--- a/packages/global/components/wrappers/components/section-feed-block.marko
+++ b/packages/global/components/wrappers/components/section-feed-block.marko
@@ -2,6 +2,7 @@
   alias=input.alias
   header=input.header
   modifiers=input.modifiers
+  query-name=input.queryName
 >
   <@query-params ...input.queryParams limit=input.limit skip=input.skip/>
   <@node-list innerJustified=false ...input.nodeList />

--- a/packages/global/components/wrappers/marko.json
+++ b/packages/global/components/wrappers/marko.json
@@ -11,6 +11,7 @@
     "@header": "string",
     "@aliases": "array",
     "@query-params": "object",
+    "@query-name": "string",
     "@node-list": "object"
   }
 }

--- a/packages/global/components/wrappers/section-feed.marko
+++ b/packages/global/components/wrappers/section-feed.marko
@@ -3,13 +3,12 @@ import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 $ const { pagination: p } = out.global;
 $ const perPage = 12;
 $ const withPagination = defaultValue(input.withPagination, true);
-$ const { modifiers } = input;
+$ const { modifiers, queryName } = input;
 $ const withAds = defaultValue(input.withAds, true);
 $ const queryParams = {
   requiresImage: false,
   ...input.queryParams,
 };
-
 <if(input.rails && input.rails.length === 1)>
   <div class="row">
     <div class="col-lg-8">
@@ -18,6 +17,7 @@ $ const queryParams = {
         header=input.header
         modifiers=modifiers
         query-params=queryParams
+        query-name=queryName
         limit=3
         skip=p.skip({ perPage })
         node-list=input.nodeList
@@ -27,6 +27,7 @@ $ const queryParams = {
         alias=input.alias
         modifiers=modifiers
         query-params=queryParams
+        query-name=queryName
         limit=3
         skip=p.skip({ perPage, skip: 3 })
         node-list=input.nodeList
@@ -36,6 +37,7 @@ $ const queryParams = {
         alias=input.alias
         modifiers=modifiers
         query-params=queryParams
+        query-name=queryName
         limit=3
         skip=p.skip({ perPage, skip: 6 })
         node-list=input.nodeList
@@ -45,12 +47,13 @@ $ const queryParams = {
         alias=input.alias
         modifiers=modifiers
         query-params=queryParams
+        query-name=queryName
         limit=3
         skip=p.skip({ perPage, skip: 9 })
         node-list=input.nodeList
       />
       <if(withPagination)>
-        <theme-section-feed-block|{ totalCount }| alias=input.alias count-only=true>
+        <theme-section-feed-block|{ totalCount }| alias=input.alias count-only=true query-name=queryName>
           <@query-params ...queryParams />
           <theme-pagination-controls
             per-page=perPage
@@ -73,6 +76,7 @@ $ const queryParams = {
         header=input.header
         modifiers=modifiers
         query-params=queryParams
+        query-name=queryName
         limit=3
         skip=p.skip({ perPage })
         node-list=input.nodeList
@@ -82,6 +86,7 @@ $ const queryParams = {
         alias=input.alias
         modifiers=modifiers
         query-params=queryParams
+        query-name=queryName
         limit=3
         skip=p.skip({ perPage, skip: 3 })
         node-list=input.nodeList
@@ -103,6 +108,7 @@ $ const queryParams = {
         alias=input.alias
         modifiers=modifiers
         query-params=queryParams
+        query-name=queryName
         limit=3
         skip=p.skip({ perPage, skip: 6 })
         node-list=input.nodeList
@@ -112,12 +118,13 @@ $ const queryParams = {
         alias=input.alias
         modifiers=modifiers
         query-params=queryParams
+        query-name=queryName
         limit=3
         skip=p.skip({ perPage, skip: 9 })
         node-list=input.nodeList
       />
       <if(withPagination)>
-        <theme-section-feed-block|{ totalCount }| alias=input.alias count-only=true>
+        <theme-section-feed-block|{ totalCount }| alias=input.alias count-only=true query-name=queryName>
           <@query-params ...queryParams />
           <theme-pagination-controls
             per-page=perPage

--- a/packages/global/templates/published-content/index.marko
+++ b/packages/global/templates/published-content/index.marko
@@ -1,0 +1,15 @@
+$ const {
+  alias,
+  name,
+  description,
+  queryParams,
+  withAds,
+} = input;
+
+<global-all-published-content-feed-layout
+  alias=alias
+  name=name
+  description=description
+  query-params=queryParams
+  with-ads=withAds
+/>

--- a/sites/bizbash.com/server/routes/index.js
+++ b/sites/bizbash.com/server/routes/index.js
@@ -3,6 +3,7 @@ const directory = require('@bizbash-media/package-global/routes/directory');
 const home = require('./home');
 const content = require('./content');
 const dynamicPages = require('./dynamic-page');
+const publishedContent = require('./published-content');
 const websiteSections = require('./website-section');
 
 module.exports = (app) => {
@@ -19,6 +20,8 @@ module.exports = (app) => {
 
   // Directory Pages have to happen after content or they wont match
   directory(app, 'resources/vendors');
+
+  publishedContent(app);
 
   // Website Sections
   websiteSections(app);

--- a/sites/bizbash.com/server/routes/published-content.js
+++ b/sites/bizbash.com/server/routes/published-content.js
@@ -1,0 +1,71 @@
+const template = require('@bizbash-media/package-global/templates/published-content/index');
+
+const types = [
+  {
+    alias: 'webinars',
+    name: 'Webinars',
+    queryParams: {
+      includeContentTypes: ['Webinar'],
+      sort: {
+        field: 'startDate',
+        order: 'asc',
+      },
+    },
+    withAds: true,
+    description: '<p>BizBash is excited to bring our audience the latest knowledge and innovation from #eventprofs with our webinars and virtual showcases. Take a look at the latest trends in event tech, design, food and beverage, and more!</p><p>Looking to host a webinar with BizBash? Inquire <a href="https://www.bizbashlive.com/advertise" title="Advertise with Bizbash">here</a>.</p><p>Interested in sharing your insights with the BizBash virtual audience? Submit to speak <a href="https://www.bizbash.com/production-strategy/programming-entertainment/article/21109266/call-for-speakers-how-should-event-planners-kick-off-a-new-decade" title="Call for Speaking">here</a>.</p>',
+  },
+  {
+    alias: 'white-papers',
+    name: 'White Papers',
+    queryParams: {
+      includeContentTypes: ['Whitepaper'],
+    },
+    withAds: true,
+  },
+  {
+    alias: 'videos',
+    name: 'Videos',
+    queryParams: {
+      includeContentTypes: ['Video'],
+    },
+    withAds: true,
+  },
+  {
+    alias: 'podcast',
+    name: 'Podcast',
+    queryParams: {
+      includeContentTypes: ['Podcast'],
+    },
+    withAds: true,
+  },
+  {
+    alias: 'downloads',
+    name: 'Downoloads',
+    queryParams: {
+      includeContentTypes: ['Document'],
+    },
+    withAds: true,
+  },
+];
+
+module.exports = (app) => {
+  // app.get('/events', (_, res) => { res.marko(events); });
+  // app.get('/supplier-events', (_, res) => { res.marko(supplierEvents); });
+  types.forEach(({
+    alias,
+    name,
+    description,
+    queryParams,
+    withAds,
+  }) => {
+    app.get(`/${alias}`, (_, res) => {
+      res.marko(template, {
+        alias,
+        name,
+        description,
+        queryParams,
+        withAds,
+      });
+    });
+  });
+};

--- a/sites/bizbash.com/server/routes/published-content.js
+++ b/sites/bizbash.com/server/routes/published-content.js
@@ -31,7 +31,7 @@ const types = [
     withAds: true,
   },
   {
-    alias: 'podcast',
+    alias: 'podcasts',
     name: 'Podcast',
     queryParams: {
       includeContentTypes: ['Podcast'],

--- a/sites/bizbash.com/server/routes/published-content.js
+++ b/sites/bizbash.com/server/routes/published-content.js
@@ -1,5 +1,7 @@
 const template = require('@bizbash-media/package-global/templates/published-content/index');
+const events = require('../templates/published-content/events');
 
+const now = (new Date()).valueOf();
 const types = [
   {
     alias: 'webinars',
@@ -46,11 +48,23 @@ const types = [
     },
     withAds: true,
   },
+  {
+    alias: 'supplier-events',
+    name: 'Supplier Events',
+    queryParams: {
+      includeContentTypes: ['Event'],
+      endingAfter: now,
+      sort: {
+        field: 'startDate',
+        order: 'asc',
+      },
+    },
+    withAds: true,
+  },
 ];
 
 module.exports = (app) => {
-  // app.get('/events', (_, res) => { res.marko(events); });
-  // app.get('/supplier-events', (_, res) => { res.marko(supplierEvents); });
+  app.get('/:alias(events)', (_, res) => { res.marko(events); });
   types.forEach(({
     alias,
     name,

--- a/sites/bizbash.com/server/templates/published-content/events.marko
+++ b/sites/bizbash.com/server/templates/published-content/events.marko
@@ -1,0 +1,61 @@
+$ const { id, alias, name, pageNode } = input;
+$ const { GAM } = out.global
+
+<theme-default-page id=id alias=alias name=name>
+  <@head>
+    <marko-web-gtm-website-section-context|{ context }| alias=alias>
+      <marko-web-gtm-push data=context />
+    </marko-web-gtm-website-section-context>
+    <marko-web-resolve-page|{ data: section }| node=pageNode>
+      <marko-web-p1-events-track-website-section node=section />
+    </marko-web-resolve-page>
+    <${input.head} />
+  </@head>
+  <if(GAM.enableRevealAd)>
+    <@above-container>
+      <theme-reveal-ad-handler select-all-targets=true path=GAM.getAdUnit({ name: "reskin", aliases: ["events"] }).path id="reveal-ad" />
+    </@above-container>
+  </if>
+  <@page>
+    <marko-web-page-wrapper>
+      <@section>
+        <theme-section-feed-block
+          alias="virtual-events"
+          header=true
+          modifiers=["virtual-events"]
+        >
+          <@header>
+            The latest virtual events from BizBash.
+          </@header>
+          <@query-params
+            include-content-types=["Event"]
+            sort= { field: 'startDate', order: 'asc' }
+            limit=18
+          />
+          <@node-list innerJustified=false ...input.nodeList />
+          <@node with-section=true with-dates=true />
+        </theme-section-feed-block>
+      </@section>
+
+      <@section>
+        <theme-section-feed-block
+          alias="live-events"
+          header="Live Events"
+          modifiers=["live-events"]
+        >
+          <@header>
+            The latest live events in partnership with Connect.
+          </@header>
+          <@query-params
+            include-content-types=["Event"]
+            sort= { field: 'startDate', order: 'asc' }
+            limit=18
+          />
+          <@node-list innerJustified=false ...input.nodeList />
+          <@node with-section=true with-dates=true />
+        </theme-section-feed-block>
+      </@section>
+
+    </marko-web-page-wrapper>
+  </@page>
+</theme-default-page>


### PR DESCRIPTION
Add all-published-content routes/templates/layouts for /webinars, /white-papaers, /videos, /downloads, /podcasts & /supplier-events

Also add a custom landing page for /events that has two section displaying event scheduled to /virtual-events & /live-events.  

![videos](https://user-images.githubusercontent.com/3845869/210870055-5fbcc37b-9f0f-45eb-b535-4f8c36773b60.jpeg)
![whitepapers](https://user-images.githubusercontent.com/3845869/210870066-35e68989-3ae8-45c5-832f-e967cdf4d5ec.jpeg)


![webinars](https://user-images.githubusercontent.com/3845869/210898554-f2f56a41-3ecb-4e83-9a79-91759a8fef2a.jpeg)
