### PR TITLE
Adjustments to new layout

### DIFF
--- a/packages/global/components/blocks/industry-buzz.marko
+++ b/packages/global/components/blocks/industry-buzz.marko
@@ -4,6 +4,8 @@ import { defaultValue } from "@parameter1/base-cms-marko-web/utils";
 
 $ const viewMore = defaultValue(input.viewMore, true);
 
+$ const { i18n } = out.global;
+
 $ const queryParams = {
   sectionAlias: input.alias,
   limit: 3,
@@ -34,7 +36,7 @@ $ const blockName = "industry-buzz";
           <if(viewMore && section && section.canonicalPath)>
             <marko-web-element block-name=blockName name="view-more">
               <marko-web-link href=section.canonicalPath>
-                ${viewMore} &raquo;
+                ${i18n("View more")} &raquo;
               </marko-web-link>
             </marko-web-element>
           </if>
@@ -58,5 +60,12 @@ $ const blockName = "industry-buzz";
         />
       </@slot>
     </theme-card-deck-flow>
+    <if(viewMore && section && section.canonicalPath)>
+      <marko-web-element block-name=blockName name="view-more-bottom">
+        <marko-web-link href=section.canonicalPath>
+          ${i18n("View more")} &raquo;
+        </marko-web-link>
+      </marko-web-element>
+    </if>
   </marko-web-block>
 </marko-web-query>

--- a/packages/global/components/blocks/industry-buzz.marko
+++ b/packages/global/components/blocks/industry-buzz.marko
@@ -1,0 +1,62 @@
+import queryFragment from "@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/opinion-block";
+import sectionFragment from "@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/section-info";
+import { defaultValue } from "@parameter1/base-cms-marko-web/utils";
+
+$ const viewMore = defaultValue(input.viewMore, true);
+
+$ const queryParams = {
+  sectionAlias: input.alias,
+  limit: 3,
+  queryFragment,
+  sectionFragment,
+};
+
+$ const blockName = "industry-buzz";
+
+<marko-web-query|{ nodes, section: querySection }| name="website-scheduled-content" params=queryParams>
+  $ const section = { ...querySection, ...input.section };
+  $ const title = input.title || section && section.name;
+  $ const description = input.description || section && section.description || input.defaultDescription;
+  <marko-web-block name=blockName>
+    <if(title)>
+      <marko-web-element block-name=blockName name="header">
+        <marko-web-element block-name=blockName name="header-left">
+          <marko-web-element block-name=blockName name="title">
+            ${title}
+          </marko-web-element>
+          <if(description)>
+            <marko-web-element block-name=blockName name="description">
+              $!{description}
+            </marko-web-element>
+          </if>
+        </marko-web-element>
+        <marko-web-element block-name=blockName name="header-right">
+          <if(viewMore && section && section.canonicalPath)>
+            <marko-web-element block-name=blockName name="view-more">
+              <marko-web-link href=section.canonicalPath>
+                ${viewMore} &raquo;
+              </marko-web-link>
+            </marko-web-element>
+          </if>
+        </marko-web-element>
+      </marko-web-element>
+    </if>
+    <theme-card-deck-flow
+      cols=3
+      nodes=nodes
+      modifiers=[blockName]
+    >
+      <@slot|{ node }|>
+        <theme-content-node
+          card=true
+          flush=true
+          full-height=true
+          node=node
+          modifiers=[blockName]
+          with-attribution=true
+          with-section=false
+        />
+      </@slot>
+    </theme-card-deck-flow>
+  </marko-web-block>
+</marko-web-query>

--- a/packages/global/components/blocks/marko.json
+++ b/packages/global/components/blocks/marko.json
@@ -13,5 +13,8 @@
   },
   "<global-native-x-announcement-block>": {
     "template": "./native-x-announcement.marko"
+  },
+  "<global-industry-buzz-block>": {
+    "template": "./industry-buzz.marko"
   }
 }

--- a/packages/global/components/blocks/marko.json
+++ b/packages/global/components/blocks/marko.json
@@ -10,5 +10,8 @@
   },
   "<global-most-popular-list-block>": {
     "template": "./most-popular-list.marko"
+  },
+  "<global-native-x-announcement-block>": {
+    "template": "./native-x-announcement.marko"
   }
 }

--- a/packages/global/components/blocks/native-x-announcement.marko
+++ b/packages/global/components/blocks/native-x-announcement.marko
@@ -5,7 +5,7 @@ $ const blockName = "announcement";
 $ const uri = nxConfig.getUri();
 $ const placement = nxConfig.getPlacement({ name, aliases });
 
-<if(uri && placement && placement.id)>
+<if(nxConfig.enable && uri && placement && placement.id)>
   <marko-web-native-x-fetch-elements|{ ads }| uri=uri id=placement.id opts={ n: 1 }>
     $ const hasAd = ads && ads.length && ads[0] && ads[0].hasCampaign;
     <if(hasAd)>

--- a/packages/global/components/blocks/native-x-announcement.marko
+++ b/packages/global/components/blocks/native-x-announcement.marko
@@ -1,0 +1,32 @@
+$ const { nativeX: nxConfig } = out.global;
+$ const name = input.placementName ? input.placementName : "announcement";
+$ const aliases = input.aliases ? input.aliases : [];
+$ const blockName = "announcement";
+$ const uri = nxConfig.getUri();
+$ const placement = nxConfig.getPlacement({ name, aliases });
+
+<if(uri && placement && placement.id)>
+  <marko-web-native-x-fetch-elements|{ ads }| uri=uri id=placement.id opts={ n: 1 }>
+    $ const hasAd = ads && ads.length && ads[0] && ads[0].hasCampaign;
+    <if(hasAd)>
+      $ const { attributes: attrs, creative, href } = ads[0];
+      $ const { title, teaser, linkText } = creative;
+
+      <marko-web-block name=blockName>
+        <marko-web-link href=href attrs=attrs.link  >
+          <marko-web-element block-name=blockName name="wrapper" attrs=attrs.container >
+            <marko-web-element block-name=blockName name="short-title">
+              ${title}
+            </marko-web-element>
+            <marko-web-element block-name=blockName name="title">
+              ${teaser}
+            </marko-web-element>
+            <marko-web-element block-name=blockName name="cta">
+              ${linkText}
+            </marko-web-element>
+          </marko-web-element>
+        </marko-web-link>
+      </marko-web-block>
+    </if>
+  </marko-web-native-x-fetch-elements>
+</if>

--- a/packages/global/components/document.marko
+++ b/packages/global/components/document.marko
@@ -75,6 +75,7 @@ $ const { gamDefer, gtmDefer, initOnly } = req.query;
       <global-site-header has-user=hasUser reg-enabled=isEnabled />
       <global-site-menu has-user=hasUser reg-enabled=isEnabled />
     </marko-web-identity-x-context>
+    <global-native-x-announcement-block />
     <${input.aboveContainer} />
   </@above-container>
   <@below-container>

--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -199,6 +199,15 @@ $ const shouldInjectAds = ["article", "blog", "video", "media-gallery", "news", 
         </div>
       </div>
       <div class="col-lg-4 page-rail">
+        <marko-web-identity-x-context|{ hasUser }|>
+          <if(!hasUser)>
+            <identity-x-newsletter-form-inline
+              login-email-placeholder="example@yourcompany.com"
+              type="inlineSection"
+            />
+          </if>
+        </marko-web-identity-x-context>
+
         <theme-gam-define-display-ad
           name="rail1"
           position="content_page"
@@ -206,7 +215,7 @@ $ const shouldInjectAds = ["article", "blog", "video", "media-gallery", "news", 
           modifiers=["max-width-300", "center", "margin-auto-x"]
           class="mb-block"
         />
-        <!-- $ const excludeContentTypes = ["Contact", "Company", "Document", "TextAd", "Promotion"];
+        $ const excludeContentTypes = ["Contact", "Company", "Document", "TextAd", "Promotion"];
         <theme-latest-content-list-block
           title=`Latest in ${primarySection.name}`
           alias=primarySection.alias
@@ -215,7 +224,7 @@ $ const shouldInjectAds = ["article", "blog", "video", "media-gallery", "news", 
         >
           <@node with-section=true with-dates=false />
           <@native-x indexes=[0] name="default" aliases=aliases />
-        </theme-latest-content-list-block> -->
+        </theme-latest-content-list-block>
         <!-- <theme-gam-define-display-ad
           name="rail2"
           position="content_page"

--- a/packages/global/config/native-x.js
+++ b/packages/global/config/native-x.js
@@ -2,5 +2,5 @@ const NativeXConfiguration = require('@parameter1/base-cms-marko-web-native-x/co
 
 module.exports = ({
   uri = 'https://bizbash.native-x.parameter1.com',
-  enabled = false,
+  enabled = true,
 } = {}) => new NativeXConfiguration(uri, { enabled });

--- a/packages/global/scss/components/industry-buzz.scss
+++ b/packages/global/scss/components/industry-buzz.scss
@@ -1,0 +1,55 @@
+.industry-buzz {
+  background-color: #f0f1f2;
+  padding: 1rem 2rem 2rem;
+
+  &__header {
+    display: flex;
+    align-items: flex-end;
+    margin-bottom: 24px;
+    justify-content: space-between;
+    @include media-breakpoint-up(md) {
+      margin-bottom: 30px;
+    }
+    @include skin-typography($style: "section-header");
+    font-size: 48px;
+  }
+
+  &__header-left {
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__view-more {
+    @include skin-typography($style: "view-more", $link-style: "primary");
+    line-height: 1.7;
+    white-space: nowrap;
+    display: none;
+    @include media-breakpoint-up(md) {
+      display: block;
+    }
+    font-size: 18px;
+  }
+
+  .node {
+    &__website-section-name {
+      @include skin-typography($style: "slug-small", $link-style: "primary");
+    }
+  }
+}
+
+.card-deck-flow {
+  $self: &;
+  &--card-deck-flow {
+    #{ $self } {
+      &__node {
+        margin-bottom: 16px;
+        @include media-breakpoint-up(md) {
+          margin-bottom: 0;
+        }
+        &:last-child {
+          margin-bottom: 0;
+        }
+      }
+    }
+  }
+}

--- a/packages/global/scss/components/industry-buzz.scss
+++ b/packages/global/scss/components/industry-buzz.scss
@@ -11,7 +11,6 @@
       margin-bottom: 30px;
     }
     @include skin-typography($style: "section-header");
-    font-size: 48px;
   }
 
   &__header-left {
@@ -28,6 +27,16 @@
       display: block;
     }
     font-size: 18px;
+  }
+
+  &__view-more-bottom {
+    @include skin-typography($style: "view-more", $link-style: "primary");
+
+    display: block;
+    margin-top: 4px;
+    @include media-breakpoint-up(md) {
+      display: none;
+    }
   }
 
   .node {

--- a/packages/global/scss/components/native-x-announcement.scss
+++ b/packages/global/scss/components/native-x-announcement.scss
@@ -1,0 +1,55 @@
+.announcement {
+  z-index: 15000;
+  background-color: $primary;
+  border-bottom: 1px solid #c4c6cb;
+  font-weight: $font-weight-bold;
+  font-size: 12px;
+  &__wrapper {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    max-width: $marko-web-document-container-max-width;
+    margin: map-get($spacers, 2) auto;
+    margin-left: auto;
+    margin-right: auto;
+    @media (max-width: $marko-web-document-container-max-width) {
+      padding: 0 ($marko-web-page-wrapper-padding * 2);
+    }
+  }
+  a,
+  a:hover {
+    text-decoration: none;
+  }
+  &__title,
+  &__short-title,
+  &__cta {
+    font-size: 12px;
+    font-weight: 700;
+    height: 20px;
+    letter-spacing: 0.3px;
+    line-height: 20px;
+    white-space: nowrap;
+  }
+  &__short-title {
+    color: $white;
+    @media (min-width: 728px) {
+      display: none;
+    }
+    max-width: 75ch;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  &__title {
+    color: $white;
+    @media (max-width: 728px) {
+      display: none;
+    }
+    max-width: 150ch;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  &__cta {
+    color: $white;
+    margin-left: 1em;
+  }
+}

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -404,32 +404,24 @@ label {
 }
 // End right rail content layout CSS
 
-// page & block title
+// update block/page title font zies
 .page--load-more .node-list,
-.top-stories {
+.top-stories,
+.related-storie,
+.content-card-deck,
+.section-card-list,
+.magazine-issues,
+.industry-buzz  {
   &__header {
     font-size: 48px;
-  }
-}
-.related-stories,
-.content-card-deck {
-  &__header {
-    font-size: 48px;
+    @media (max-width: map-get($theme-site-header-breakpoints, small-logo)) {
+      font-size: 36px;
+    }
   }
   &__view-more {
     font-size: 18px;
   }
-}
-.section-card-list {
-  &__header {
-    font-size: 48px;
-  }
-}
-.magazine-issues {
-  &__header {
-    font-size: 48px;
-    padding-top: 0px;
-  }
+
 }
 .section-cards {
   &__header {

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -118,7 +118,7 @@ label {
   }
 
   &__title a {
-    max-height: 80px
+    max-height: 90px
   }
 
   &--video-content-type {

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -28,6 +28,7 @@
 @import "./components/site-navbar-c";
 // @import "./components/sticky-footer";
 @import "./components/user";
+@import "./components/native-x-announcement";
 
 body {
   -webkit-font-smoothing: antialiased;
@@ -607,4 +608,8 @@ label {
       }
     }
   }
+}
+
+.marko-web-search-sort-by {
+  visibility: hidden;
 }

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -29,6 +29,7 @@
 // @import "./components/sticky-footer";
 @import "./components/user";
 @import "./components/native-x-announcement";
+@import "./components/industry-buzz";
 
 body {
   -webkit-font-smoothing: antialiased;

--- a/sites/bizbash.com/config/native-x.js
+++ b/sites/bizbash.com/config/native-x.js
@@ -6,8 +6,9 @@ const config = configureNativeX(
 
 config
   .setAliasPlacements('default', [
-    { name: 'primary', id: '5d4af41d2ab3e700014e2dd6' },
+    { name: 'default', id: '5d4af41d2ab3e700014e2dd6' },
     { name: 'announcement', id: '63ab2696d1addd000187fe87' },
+    { name: 'webinars', id: '63c558c2ee1f4c0001de3847' },
   ])
   .setAliasPlacements('catering-design', [
     { name: 'primary', id: '5d4b04513bb2db00018cfa1a' },

--- a/sites/bizbash.com/config/native-x.js
+++ b/sites/bizbash.com/config/native-x.js
@@ -7,9 +7,7 @@ const config = configureNativeX(
 config
   .setAliasPlacements('default', [
     { name: 'primary', id: '5d4af41d2ab3e700014e2dd6' },
-  ])
-  .setAliasPlacements('announcement', [
-    { name: 'primary', id: '63ab2696d1addd000187fe87' },
+    { name: 'announcement', id: '63ab2696d1addd000187fe87' },
   ])
   .setAliasPlacements('catering-design', [
     { name: 'primary', id: '5d4b04513bb2db00018cfa1a' },

--- a/sites/bizbash.com/config/newsletter.js
+++ b/sites/bizbash.com/config/newsletter.js
@@ -2,14 +2,14 @@
 const defaults = {
   // disabled: process.env.DISABLE_IDX_NEWSLETTER_SIGNUP === 'true',
   name: 'Don’t Miss Out',
-  description: 'Ideas, inspiration and the hottest industry events directly to your inbox.',
+  description: 'BizBash editors search the globe to deliver ideas, inspiration and the hottest industry events directly to your inbox.',
 };
 
 module.exports = {
   signupBanner: {
     ...defaults,
     name: 'You\'re Invited!',
-    imagePath: 'files/base/pmmi/all/image/static/newsletter-pushdown/pw-iphone.png',
+    imagePath: '/files/base/bizbash/bzb/image/static/logo/eventIndustryNo1Newsletter.png',
   },
   signupBannerLarge: {
     ...defaults,

--- a/sites/bizbash.com/config/site.js
+++ b/sites/bizbash.com/config/site.js
@@ -78,7 +78,7 @@ module.exports = {
       'hello@weare4EVR.com',
     ],
   },
-  setSearchSortFieldToScore: true,
+  setSearchSortFieldToScore: false,
   publishedContent: {
     webinars: {
       title: 'Webinars',

--- a/sites/bizbash.com/server/templates/index.marko
+++ b/sites/bizbash.com/server/templates/index.marko
@@ -132,7 +132,7 @@ $ const promise = websiteSectionContentLoader(apollo, {
             <theme-content-card-deck-block
               alias="on-demand/webinars-virtual-events"
               with-native-x=true
-              native-x={ name: "announcement", index: 0 }
+              native-x={ name: "webinars", index: 0 }
             >
               <@node withSection=false />
             </theme-content-card-deck-block>

--- a/sites/bizbash.com/server/templates/index.marko
+++ b/sites/bizbash.com/server/templates/index.marko
@@ -87,9 +87,9 @@ $ const promise = websiteSectionContentLoader(apollo, {
               </div>
               <div class="col-lg-4 page-rail">
                 $ const featuredNodes = featured.nodes.slice(1, 5);
-                <theme-latest-content-list-block nodes=featuredNodes title="" >
-                  <@native-x indexes=[0] name="default" aliases=aliases />
-                  <@node with-section=true with-dates=false />>
+                <theme-latest-content-list-block nodes=featuredNodes title="">
+                  <@native-x indexes=[2] name="default" aliases=aliases />
+                  <@node with-section=true with-dates=false />
                 </theme-latest-content-list-block>
               </div>
             </div>
@@ -129,7 +129,11 @@ $ const promise = websiteSectionContentLoader(apollo, {
           </@section>
 
           <@section modifiers=["background-color"]>
-            <theme-content-card-deck-block alias="on-demand/webinars-virtual-events">
+            <theme-content-card-deck-block
+              alias="on-demand/webinars-virtual-events"
+              with-native-x=true
+              native-x={ name: "announcement", index: 0 }
+            >
               <@node withSection=false />
             </theme-content-card-deck-block>
           </@section>

--- a/sites/bizbash.com/server/templates/index.marko
+++ b/sites/bizbash.com/server/templates/index.marko
@@ -158,10 +158,9 @@ $ const promise = websiteSectionContentLoader(apollo, {
           </@section>
 
           <@section modifiers=["background-color"]>
-            <theme-section-card-list-block
+            <global-industry-buzz-block
               alias="industry-buzz"
-              description=""
-              button-class="btn btn-primary"
+              view-more="View More"
             />
           </@section>
 
@@ -169,16 +168,6 @@ $ const promise = websiteSectionContentLoader(apollo, {
             <theme-section-forbes-block alias="meetings-trade-shows" query-params={ excludeContentIds: ids } reverse=true />
           </@section>
 
-          <!-- <@section>
-            <marko-web-identity-x-context|{ hasUser }|>
-              <if(!hasUser)>
-                <identity-x-newsletter-form-inline
-                  login-email-placeholder="example@yourcompany.com"
-                  type="inlineSection"
-                />
-              </if>
-            </marko-web-identity-x-context>
-          </@section> -->
         </marko-web-page-wrapper>
       </marko-web-resolve-page>
     </@page>


### PR DESCRIPTION
Requires https://github.com/parameter1/base-cms/pull/534 for Webinars' NativeX placement.

**UPDATE**: Need help with scss for mobile (industry buzz block)
<img width="1656" alt="Screen Shot 2023-01-16 at 10 22 44 PM" src="https://user-images.githubusercontent.com/64623209/212809794-5dab1e02-1b6f-46bd-ad51-cd5e2376fa5a.png">



<img width="1792" alt="Screen Shot 2023-01-12 at 10 44 53 PM" src="https://user-images.githubusercontent.com/64623209/212240091-bd06dbfa-86e9-4714-a490-8f165b390a5e.png">
<img width="1459" alt="Screen Shot 2023-01-12 at 10 44 27 PM" src="https://user-images.githubusercontent.com/64623209/212240097-2b73eaa6-dcd7-4da7-9665-66db988d04b8.png">
<img width="1497" alt="Screen Shot 2023-01-12 at 10 23 09 PM" src="https://user-images.githubusercontent.com/64623209/212240098-3c48326c-9b8d-4d7d-ba57-d9b97ca9df08.png">
