### PR TITLE
Hide Announcement ad when menu is open

### DIFF
--- a/packages/global/scss/components/native-x-announcement.scss
+++ b/packages/global/scss/components/native-x-announcement.scss
@@ -1,5 +1,4 @@
 .announcement {
-  z-index: 15000;
   background-color: $primary;
   border-bottom: 1px solid #c4c6cb;
   font-weight: $font-weight-bold;


### PR DESCRIPTION
Current:
<img width="1382" alt="Screen Shot 2023-01-20 at 10 30 35 AM" src="https://user-images.githubusercontent.com/64623209/213752305-310ce842-5aa8-483b-aa14-21624a0d5429.png">

With PR:
<img width="1373" alt="Screen Shot 2023-01-20 at 10 28 48 AM" src="https://user-images.githubusercontent.com/64623209/213752381-c54ece8b-74dc-49da-a304-6741727b1a1c.png">
