### PR TITLE
update to remove Source: from credit:before

### DIFF
--- a/packages/global/scss/components/_content-page.scss
+++ b/packages/global/scss/components/_content-page.scss
@@ -1,0 +1,8 @@
+.page-contents {
+  .primary-image {
+    &__image-credit:before {
+      content: "";
+      display: none;
+    }
+  }
+}

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -21,6 +21,7 @@
 // skin components
 @import "./components/section-feed-upcoming";
 @import "./components/content-meter";
+@import "./components/content-page";
 @import "./components/directory";
 @import "./components/directory-section-feed";
 @import "./components/content-images";


### PR DESCRIPTION
Remove the `Source: ` showing up before the primary image credit.

<img width="877" alt="Screen Shot 2023-01-23 at 12 43 07 PM" src="https://user-images.githubusercontent.com/3845869/214123261-5a979e47-191d-461c-bee4-faa88445b501.png">
