### PR TITLE
Utilize previous font for content body

### DIFF
--- a/sites/bizbash.com/server/styles/index.scss
+++ b/sites/bizbash.com/server/styles/index.scss
@@ -1,15 +1,3 @@
-@import url("https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,300i,400,400i,600,700,700i|Open+Sans:400,400i,700,700i|Roboto+Condensed:700,400|Oswald:500,700&display=swap");
-@import "../../node_modules/@parameter1/base-cms-marko-web-theme-default/scss/functions";
-
-// Fonts
-$font-source-sans-pro:    "Source Sans Pro", "Arial", sans-serif;
-$font-open-sans:          "Open Sans", "Arial", sans-serif;
-$font-oswald:             "Oswald", "Arial", sans-serif;
-$font-roboto-condensed:   "Roboto Condensed", sans-serif;
-
-$theme-font-family-sans-serif: $font-open-sans;
-$theme-font-family-page-title: $font-source-sans-pro;
-
 $theme-site-header-breakpoints: (
   hide-primary: 1100px,
   hide-secondary: 995px,
@@ -17,17 +5,31 @@ $theme-site-header-breakpoints: (
   small-text-primary: 0,
 );
 
+$marko-web-document-container-max-width: 1300px;
+
 // Colors
 $primary: #0072bb;
 
-$marko-web-document-container-max-width: 1300px;
+// Fonts
+@font-face {
+  font-family: oswald-fallback;
+  size-adjust: 81.91000000000001%; /* stylelint-disable-line property-no-unknown */
+  ascent-override: 154%; /* stylelint-disable-line property-no-unknown */
+  src: local("Arial");
+}
 
+@font-face {
+  font-family: open-sans-fallback;
+  size-adjust: 105.42999999999994%; /* stylelint-disable-line property-no-unknown */
+  ascent-override: 105%; /* stylelint-disable-line property-no-unknown */
+  src: local("Arial");
+}
 
-$skin-font-family-primary: "Source Sans Pro", "Arial", sans-serif;
-$skin-font-family-secondary: "Source Sans Pro", "Arial", sans-serif;
+$skin-font-family-primary: "Oswald", oswald-fallback, sans-serif !default;
+$skin-font-family-secondary: "Oswald", oswald-fallback, sans-serif !default;
 
-$theme-content-body-font: "Open Sans", "Arial", sans-serif;
-
+$theme-content-body-font: "Open Sans", open-sans-fallback, sans-serif;
+// $theme-content-body-font: "Oswald", open-sans-fallback, sans-serif;
 $black: #1f2937;
 $body-color: $black;
 

--- a/sites/bizbash.com/server/styles/index.scss
+++ b/sites/bizbash.com/server/styles/index.scss
@@ -1,3 +1,15 @@
+@import url("https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,300i,400,400i,600,700,700i|Open+Sans:400,400i,700,700i|Roboto+Condensed:700,400|Oswald:500,700&display=swap");
+@import "../../node_modules/@parameter1/base-cms-marko-web-theme-default/scss/functions";
+
+// Fonts
+$font-source-sans-pro:    "Source Sans Pro", "Arial", sans-serif;
+$font-open-sans:          "Open Sans", "Arial", sans-serif;
+$font-oswald:             "Oswald", "Arial", sans-serif;
+$font-roboto-condensed:   "Roboto Condensed", sans-serif;
+
+$theme-font-family-sans-serif: $font-open-sans;
+$theme-font-family-page-title: $font-source-sans-pro;
+
 $theme-site-header-breakpoints: (
   hide-primary: 1100px,
   hide-secondary: 995px,
@@ -5,31 +17,17 @@ $theme-site-header-breakpoints: (
   small-text-primary: 0,
 );
 
-$marko-web-document-container-max-width: 1300px;
-
 // Colors
 $primary: #0072bb;
 
-// Fonts
-@font-face {
-  font-family: oswald-fallback;
-  size-adjust: 81.91000000000001%; /* stylelint-disable-line property-no-unknown */
-  ascent-override: 154%; /* stylelint-disable-line property-no-unknown */
-  src: local("Arial");
-}
+$marko-web-document-container-max-width: 1300px;
 
-@font-face {
-  font-family: open-sans-fallback;
-  size-adjust: 105.42999999999994%; /* stylelint-disable-line property-no-unknown */
-  ascent-override: 105%; /* stylelint-disable-line property-no-unknown */
-  src: local("Arial");
-}
 
-$skin-font-family-primary: "Oswald", oswald-fallback, sans-serif !default;
-$skin-font-family-secondary: "Oswald", oswald-fallback, sans-serif !default;
+$skin-font-family-primary: "Source Sans Pro", "Arial", sans-serif;
+$skin-font-family-secondary: "Source Sans Pro", "Arial", sans-serif;
 
-// $theme-content-body-font: "Open Sans", open-sans-fallback, sans-serif;
-$theme-content-body-font: "Oswald", open-sans-fallback, sans-serif;
+$theme-content-body-font: "Open Sans", "Arial", sans-serif;
+
 $black: #1f2937;
 $body-color: $black;
 


### PR DESCRIPTION
Change:
<img width="995" alt="Screen Shot 2023-02-02 at 12 01 48 PM" src="https://user-images.githubusercontent.com/64623209/216406683-58d1bd8b-ab43-4c58-9146-bda23f08c66c.png">
Current:
<img width="898" alt="Screen Shot 2023-02-02 at 12 01 55 PM" src="https://user-images.githubusercontent.com/64623209/216406687-419185c2-24b9-4b9c-8778-d6ae7e4b2ea7.png">

