### PR TITLE
Utilize `with-sponsored` prop to apply the necessary slugs to content lists/blocks.

### DIFF
--- a/packages/global/components/wrappers/components/section-feed-block.marko
+++ b/packages/global/components/wrappers/components/section-feed-block.marko
@@ -3,6 +3,7 @@
   header=input.header
   modifiers=input.modifiers
   query-name=input.queryName
+  with-sponsored=true
 >
   <@query-params ...input.queryParams limit=input.limit skip=input.skip/>
   <@node-list innerJustified=false ...input.nodeList />

--- a/sites/bizbash.com/server/templates/index.marko
+++ b/sites/bizbash.com/server/templates/index.marko
@@ -113,7 +113,7 @@ $ const promise = websiteSectionContentLoader(apollo, {
           </@section>
 
           <@section>
-            <theme-section-forbes-block alias="production-strategy" query-params={ excludeContentIds: ids } />
+            <theme-section-forbes-block alias="production-strategy" with-sponsored=true query-params={ excludeContentIds: ids } />
           </@section>
 
           <!-- <@section modifiers=["background-color"]>
@@ -125,7 +125,7 @@ $ const promise = websiteSectionContentLoader(apollo, {
           </@section> -->
 
           <@section>
-            <theme-section-forbes-block alias="catering-design" query-params={ excludeContentIds: ids } reverse=true />
+            <theme-section-forbes-block alias="catering-design" with-sponsored=true query-params={ excludeContentIds: ids } reverse=true />
           </@section>
 
           <@section modifiers=["background-color"]>
@@ -139,7 +139,7 @@ $ const promise = websiteSectionContentLoader(apollo, {
           </@section>
 
           <@section>
-            <theme-section-forbes-block alias="event-tech-virtual" query-params={ excludeContentIds: ids } reverse=true />
+            <theme-section-forbes-block alias="event-tech-virtual" with-sponsored=true query-params={ excludeContentIds: ids } reverse=true />
           </@section>
 
           $ const publicationIds = site.get("magazine.publicationIds");
@@ -150,7 +150,7 @@ $ const promise = websiteSectionContentLoader(apollo, {
           </if>
 
           <@section>
-            <theme-section-forbes-block alias="venues-destinations" query-params={ excludeContentIds: ids } />
+            <theme-section-forbes-block alias="venues-destinations" with-sponsored=true query-params={ excludeContentIds: ids } />
           </@section>
 
           <@section modifiers=["background-color"]>
@@ -161,7 +161,7 @@ $ const promise = websiteSectionContentLoader(apollo, {
           </@section>
 
           <@section>
-            <theme-section-forbes-block alias="meetings-trade-shows" query-params={ excludeContentIds: ids } reverse=true />
+            <theme-section-forbes-block alias="meetings-trade-shows" with-sponsored=true query-params={ excludeContentIds: ids } reverse=true />
           </@section>
 
         </marko-web-page-wrapper>


### PR DESCRIPTION
**REQUIRES: https://github.com/parameter1/base-cms/pull/550**

Section Feed example:
![Screenshot from 2023-02-02 12-44-28](https://user-images.githubusercontent.com/46794001/216422679-d8f310d8-8c15-421c-a9c1-bf43f1a31b45.png)

Various Forbes blocks:
![Screenshot from 2023-02-02 12-44-44](https://user-images.githubusercontent.com/46794001/216422758-a53a6112-2b09-4771-be37-fcf9c8dd646e.png)
![Screenshot from 2023-02-02 12-44-48](https://user-images.githubusercontent.com/46794001/216422760-94ad2440-9b85-4201-9766-cc6d09fa4956.png)
![Screenshot from 2023-02-02 12-44-56](https://user-images.githubusercontent.com/46794001/216422761-57097fdb-31ca-4363-8149-a181f47bbe50.png)
![Screenshot from 2023-02-02 12-45-00](https://user-images.githubusercontent.com/46794001/216422763-ead3aecf-1934-47f6-a59f-37645ffb3418.png)
