### PR TITLE
Add custom gam targeting to bizbash monorail.

### DIFF
--- a/packages/global/components/gam-content-targeting.marko
+++ b/packages/global/components/gam-content-targeting.marko
@@ -1,0 +1,19 @@
+import { getAsObject, get, getAsArray } from "@parameter1/base-cms-object-path";
+import gamContentCategories from "../utils/gam-content-categories";
+
+$ const content = getAsObject(input, "obj");
+$ const { id, type } = content;
+$ const companyIds = getAsArray(content, "companies.edges").map(({ node }) => node.id);
+$ const companyId = get(content, "company.id");
+$ const categories = gamContentCategories(content);
+$ if (companyId) companyIds.unshift(companyId);
+$ const keyValues = {
+  cont_id: id,
+  cont_type: type,
+  ...(companyIds.length && {
+    companies: companyIds.join("|"),
+    Company: companyIds.shift(),
+  }),
+  ...(categories && { ...categories }),
+};
+<marko-web-gam-targeting key-values=keyValues />

--- a/packages/global/components/gam-content-targeting.marko
+++ b/packages/global/components/gam-content-targeting.marko
@@ -2,14 +2,23 @@ import { getAsObject, get, getAsArray } from "@parameter1/base-cms-object-path";
 import gamContentCategories from "../utils/gam-content-categories";
 
 $ const content = getAsObject(input, "obj");
-$ const { id, type } = content;
+$ const { id, type, primarySection } = content;
 $ const companyIds = getAsArray(content, "companies.edges").map(({ node }) => node.id);
 $ const companyId = get(content, "company.id");
 $ const categories = gamContentCategories(content);
 $ if (companyId) companyIds.unshift(companyId);
 $ const keyValues = {
+  // legacy content id key
   cont_id: id,
+  // content id key
+  content_id: id,
+  // legacy content type key
   cont_type: type,
+  // content type key
+  content_type: type,
+  // legacy section id key
+  sect_id: primarySection.id,
+  primary_section_id: primarySection.id,
   ...(companyIds.length && {
     companies: companyIds.join("|"),
     Company: companyIds.shift(),

--- a/packages/global/components/layouts/content/wrapper.marko
+++ b/packages/global/components/layouts/content/wrapper.marko
@@ -13,6 +13,7 @@ $ const alias = get(input, "primarySection.alias");
     </marko-web-gtm-content-context>
     <marko-web-resolve-page|{ data: content }| node=pageNode>
       <marko-web-p1-events-track-content node=content />
+      <global-gam-content-targeting-element obj=content />
     </marko-web-resolve-page>
   </@head>
   <if(GAM.enableRevealAd)>

--- a/packages/global/components/marko.json
+++ b/packages/global/components/marko.json
@@ -8,6 +8,10 @@
   "<global-sponsored-label-logo>": {
     "template": "./sponsored-label-logo.marko"
   },
+  "<global-gam-content-targeting-element>": {
+    "template": "./gam-content-targeting.marko",
+    "@obj": "object"
+  },
   "<global-sponsored-section-logo>": {
     "template": "./sponsored-section-logo.marko"
   },

--- a/packages/global/utils/gam-content-categories.js
+++ b/packages/global/utils/gam-content-categories.js
@@ -1,0 +1,17 @@
+const { getAsArray } = require('@parameter1/base-cms-object-path');
+
+const categories = (obj, key, value) => ([...new Set([
+  ...getAsArray(obj, key),
+  ...(value ? [value.name] : []),
+])]);
+
+module.exports = content => getAsArray(content, 'taxonomy.edges')
+  .map(({ node }) => node.hierarchy)
+  .reduce((obj, hierarchy) => {
+    const [primary, secondary, tertiary] = hierarchy;
+    return {
+      primary_cats: categories(obj, 'primary_cats', primary),
+      secondary_cats: categories(obj, 'secondary_cats', secondary),
+      tertiary_cats: categories(obj, 'tertiary_cats', tertiary),
+    };
+  }, {});


### PR DESCRIPTION

This will add the cont_id/content_id, cont_type/content_type, sect_id/section_id, companies, Company, primary_cats, secondary_cats & tertiary_cats  to be sent to GAM when present.

<img width="1758" alt="Screen Shot 2023-02-20 at 12 35 05 PM" src="https://user-images.githubusercontent.com/3845869/220179347-1b4ce3ee-d3c1-4595-8589-abd254c107c9.png">
