### PR TITLE
Move Reveal-ad styling to global

### DIFF
--- a/packages/global/scss/components/_reveal-ad.scss
+++ b/packages/global/scss/components/_reveal-ad.scss
@@ -1,0 +1,33 @@
+$marko-web-reveal-ad-box-shadow-light:  0 4px 8px 0 rgba(255, 255, 255, .2), 0 6px 20px 0 rgba(255, 255, 255, .19) !default;
+$marko-web-reveal-ad-box-shadow-dark:   0 4px 8px 0 rgba(0, 0, 0, .2), 0 6px 20px 0 rgba(0, 0, 0, .19) !default;
+$marko-web-reveal-ad-link-margin-y:     1.5rem !default;
+$marko-web-reveal-ad-link-margin-x:     0 !default;
+
+.reveal-ad-background {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background-repeat: no-repeat;
+  background-position: top center;
+  background-size: cover;
+}
+
+.reveal-ad {
+  position: relative;
+  width: 100%;
+  &--light-shadow {
+    box-shadow: $marko-web-reveal-ad-box-shadow-light;
+  }
+  &--dark-shadow {
+    box-shadow: $marko-web-reveal-ad-box-shadow-dark;
+  }
+  a {
+    display: block;
+    width: 100%;
+    padding: $marko-web-reveal-ad-link-margin-y $marko-web-reveal-ad-link-margin-x;
+    text-align: center;
+  }
+}

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -10,8 +10,8 @@
 // Bottom Sticky Leader Board
 @import "../../node_modules/@parameter1/base-cms-marko-web-gam/scss/fixed-ad-bottom";
 // Reveal Ad CSS
-@import "../../node_modules/@parameter1/base-cms-marko-web-reveal-ad/scss/reveal-ad";
-@import "../../node_modules/@parameter1/base-cms-marko-web-theme-monorail/scss/components/reveal-ad";
+// @import "../../node_modules/@parameter1/base-cms-marko-web-reveal-ad/scss/reveal-ad";
+// @import "../../node_modules/@parameter1/base-cms-marko-web-theme-monorail/scss/components/reveal-ad";
 
 // package component css inclusions
 @import "../../node_modules/@parameter1/base-cms-marko-web-theme-monorail/scss/components/blocks/directory-facets";
@@ -32,6 +32,7 @@
 @import "./components/user";
 @import "./components/native-x-announcement";
 @import "./components/industry-buzz";
+@import "./components/reveal-ad";
 
 body {
   -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
Dev Homepage:
<img width="1589" alt="Screen Shot 2023-02-22 at 12 35 30 PM" src="https://user-images.githubusercontent.com/64623209/220726262-be9803d9-bf2e-4838-83b5-0ee7eb89ce6c.png">
Prod Test Reskin:
<img width="1781" alt="Screen Shot 2023-02-22 at 12 36 56 PM" src="https://user-images.githubusercontent.com/64623209/220726277-8fe03a6f-511f-4aa3-a72c-abbac72f60b7.png">
Dev Test Reskin:
<img width="897" alt="Screen Shot 2023-02-22 at 12 37 05 PM" src="https://user-images.githubusercontent.com/64623209/220726287-764abda3-e844-4187-b5c2-f1782348cbd5.png">
