### PR TITLE
Restore `global-body-media-gallery-block`s to Top List content pages

### DIFF
--- a/packages/global/components/blocks/content-page/body-media-gallery.marko
+++ b/packages/global/components/blocks/content-page/body-media-gallery.marko
@@ -1,0 +1,26 @@
+import { getAsArray, getAsObject } from "@parameter1/base-cms-object-path";
+import { buildImgixUrl } from "@parameter1/base-cms-image";
+
+$ const block = 'page-body-media-gallery';
+$ const gallery = getAsObject(input, 'gallery');
+$ const images = getAsArray(gallery, 'images.edges').map(({ node }) => node);
+
+<if(images.length)>
+  <div class=block>
+    <h6 class=`${block}__title`>
+      <marko-web-content-short-name link=true obj=gallery />
+    </h6>
+    <div class=`${block}__row`>
+      <for|image| of=images>
+        <div class=`${block}__col`>
+          <marko-web-link class=`${block}__link` href=`${gallery.canonicalPath}#image-${image.id}` title="View Image in Gallery" >
+            <img src=buildImgixUrl(image.src, input.imageOptions) alt=image.alt />
+            <div class=`${block}__overlay`>
+              <span class=`${block}__image-name`>${image.displayName}</span>
+            </div>
+          </marko-web-link>
+        </div>
+      </for>
+    </div>
+  </div>
+</if>

--- a/packages/global/components/blocks/content-page/marko.json
+++ b/packages/global/components/blocks/content-page/marko.json
@@ -1,0 +1,12 @@
+{
+  "<global-body-media-gallery-block>": {
+    "template": "./body-media-gallery.marko",
+    "@gallery": "array",
+    "@image-options": {
+      "type": "object",
+      "default-value": {
+          "w": 352, "h": 198, "fit": "crop", "crop": "focalpoint", "fpX": 0.5, "fpY": 0.5
+      }
+    }
+  }
+}

--- a/packages/global/components/blocks/marko.json
+++ b/packages/global/components/blocks/marko.json
@@ -1,5 +1,6 @@
 {
   "taglib-imports": [
+    "./content-page/marko.json",
     "./load-more/marko.json"
   ],
   "<global-newsletter-signup-banner-large-block>": {

--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -184,6 +184,15 @@ $ const shouldInjectAds = ["article", "blog", "video", "media-gallery", "news", 
                   </if>
                 </if>
 
+                <if(content.type === 'top-list')>
+                  $ const galleries = getAsArray(content, 'relatedTo.edges').map(({ node }) => node).filter(node => node.type === 'media-gallery');
+                  <if(galleries.length)>
+                    <for|gallery| of=galleries>
+                      <global-body-media-gallery-block gallery=gallery />
+                    </for>
+                  </if>
+                </if>
+
                 <if(displayReadNext)>
                   <theme-read-next-block
                     content-id=id

--- a/packages/global/scss/components/_page-body-media-gallery.scss
+++ b/packages/global/scss/components/_page-body-media-gallery.scss
@@ -1,0 +1,75 @@
+.page-body-media-gallery {
+  &__title {
+    margin-bottom: $theme-page-body-media-gallery-title-margin;
+    font-family: $theme-page-body-media-gallery-title-font-family;
+    font-size: $theme-page-body-media-gallery-title-font-size;
+    font-weight: $theme-page-body-media-gallery-title-font-weight;
+    line-height: $theme-page-body-media-gallery-title-line-height;
+    color: $theme-page-body-media-gallery-title-color;
+
+    a {
+      &:hover {
+        text-decoration: none;
+      }
+    }
+  }
+  $spacing: $grid-gutter-width * 0.25;
+
+  &__row {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    margin-right: -#{$spacing};
+    margin-bottom: map-get($spacers, block);
+    margin-left: -#{$spacing};
+    @include media-breakpoint-down(xs) {
+      margin-right: 0;
+      margin-left: 0;
+    }
+  }
+  &__col {
+    @include make-col-ready();
+    @include media-breakpoint-up(sm) {
+      @include make-col(6);
+    }
+    @include media-breakpoint-up(md) {
+      @include make-col(4);
+    }
+    @include media-breakpoint-down(xs) {
+      padding-right: 0;
+      padding-left: 0;
+    }
+    padding-right: $spacing;
+    padding-left: $spacing;
+    margin-bottom: $spacing * 2;
+  }
+  &__link {
+    position: relative;
+    display: block;
+    img {
+      width: 100%;
+      height: auto;
+    }
+  }
+  &__overlay {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    display: flex;
+    align-items: center;
+    padding: 1rem;
+    text-align: center;
+    background: $theme-page-body-media-gallery-image-overlay-bg;
+  }
+  &__image-name {
+    margin: 0 auto;
+    font-family: $theme-page-body-media-gallery-image-name-font-family;
+    font-size: $theme-page-body-media-gallery-image-name-font-size;
+    font-weight: $theme-page-body-media-gallery-image-name-font-weight;
+    line-height: $theme-page-body-media-gallery-image-name-line-height;
+    color: $theme-page-body-media-gallery-image-name-color;
+    text-shadow: $theme-page-body-media-gallery-image-name-text-shadow;
+  }
+}

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -33,6 +33,7 @@
 @import "./components/user";
 @import "./components/native-x-announcement";
 @import "./components/industry-buzz";
+@import "./components/page-body-media-gallery";
 
 body {
   -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
This includes minor tweaks to the CSS to have the header links match others on the new theme, otherwise unchanged from how these worked on the "old site".

Various screenshots at different resolutions to show responsiveness:
![Screenshot from 2023-03-01 12-14-51](https://user-images.githubusercontent.com/46794001/222228229-c139c418-81ed-4885-8a60-5a6cda4c28c9.png)
![Screenshot from 2023-03-01 12-14-56](https://user-images.githubusercontent.com/46794001/222228236-67812342-4798-4d7a-99b3-b8f965a4ab9f.png)
![Screenshot from 2023-03-01 12-15-16](https://user-images.githubusercontent.com/46794001/222228239-b947b095-1aae-4d8f-afe2-d8fbc6ae200b.png)
![Screenshot from 2023-03-01 12-15-25](https://user-images.githubusercontent.com/46794001/222228242-a48f79c8-b653-468e-b113-649b0dbb740c.png)
![Screenshot from 2023-03-01 12-16-32](https://user-images.githubusercontent.com/46794001/222228247-f8c5462b-d369-47df-a16f-b867a8a5cd2d.png)
![Screenshot from 2023-03-01 12-16-39](https://user-images.githubusercontent.com/46794001/222228250-b146f17e-3d3e-4698-bd92-a622327562ba.png)
