### PR TITLE
Add welcome ad call to document.marko

### DIFF
--- a/packages/global/components/document.marko
+++ b/packages/global/components/document.marko
@@ -71,6 +71,7 @@ $ const { gamDefer, gtmDefer, initOnly } = req.query;
     <${input.aboveWrapper} />
   </@above-wrapper>
   <@above-container>
+    <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "wa", aliases: [] }) />
     <marko-web-identity-x-context|{ hasUser, isEnabled }|>
       <global-site-header has-user=hasUser reg-enabled=isEnabled />
       <global-site-menu has-user=hasUser reg-enabled=isEnabled />


### PR DESCRIPTION
ad the welcome ad unit call to the document.marko above-container call as it is not alias based for ad unit and should be on ever page.

<img width="1322" alt="Screen Shot 2023-04-05 at 10 23 18 AM" src="https://user-images.githubusercontent.com/3845869/230128037-9221bb1d-d795-458a-be08-2d6bc2329fea.png">
