### PR TITLE
Add css to hide space holder for welcome ad

### DIFF
--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -608,3 +608,7 @@ label {
 .marko-web-search-sort-by {
   visibility: hidden;
 }
+
+div[id*="div-gpt-ad"]:has(div[id*="/wa"]) {
+  height: 0;
+}


### PR DESCRIPTION
When the welcome ad is fired it add is place holder dive that needs to have a height of 0 applied.