### PR TITLE
Remove "row-reverse" modifier from Whitepapers & E-Books homepage block

### DIFF
--- a/sites/bizbash.com/server/templates/index.marko
+++ b/sites/bizbash.com/server/templates/index.marko
@@ -105,7 +105,7 @@ $ const promise = websiteSectionContentLoader(apollo, {
             />
           </@section>
 
-          <@section modifiers=["row-reverse"]>
+          <@section>
             <theme-content-card-deck-block
               query-params={ limit: 3, includeContentTypes: ["Whitepaper", "Ebook"], queryFragment }
               query-name="all-published-content"


### PR DESCRIPTION
PROD:
![Screenshot from 2023-04-28 09-51-28](https://user-images.githubusercontent.com/46794001/235180760-e682b5a7-c7e9-4109-a69b-913c76cd0bcb.png)

DEV:
![Screenshot from 2023-04-28 09-52-31](https://user-images.githubusercontent.com/46794001/235180764-1a01bb57-09d7-488e-9060-6d5387179ac4.png)
