### PR TITLE
Allow for gtmUserFields keyObjectKey config

### DIFF
--- a/packages/global/components/document.marko
+++ b/packages/global/components/document.marko
@@ -53,6 +53,12 @@ $ const { gamDefer, gtmDefer, initOnly } = req.query;
 
     <${input.head} />
 
+    <marko-web-identity-x-context|{ hasUser, user }|>
+      <if(hasUser && user.id)>
+        <marko-web-gtm-push data={ user: site.get('identityX').getGTMUserData(user), user_id: user.id} />
+      </if>
+    </marko-web-identity-x-context>
+
     <!-- start gtm -->
     <marko-web-gtm-start />
 


### PR DESCRIPTION
This allows for seting the reader frieldly key to pair the objectIds answer value to to send to gtm with the user id